### PR TITLE
fix(ci): authenticate semantic release tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       pull-requests: write
     env:
       CYPRESS_INSTALL_BINARY: '0'
-      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
       RELEASE_BRANCH: ${{ github.event.repository.default_branch }}
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -25316,9 +25316,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -31525,10 +31525,20 @@
       }
     },
     "node_modules/postcss-loader/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25316,9 +25316,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -31525,20 +31525,10 @@
       }
     },
     "node_modules/postcss-loader/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -33,6 +33,8 @@ export default {
     [
       '@semantic-release/github',
       {
+        failCommentCondition: false,
+        releasedLabels: false,
         assets: [
           {
             label: 'npm package tarball',

--- a/tools/scripts/validate-automation.mjs
+++ b/tools/scripts/validate-automation.mjs
@@ -52,6 +52,14 @@ assert(
   /\bpackage-manager-cache:\s*false\b/.test(releaseWorkflow),
   'Release builds must disable the shared package-manager cache.',
 );
+assert(
+  /\bGITHUB_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/.test(releaseWorkflow),
+  'Semantic Release must receive github.token as GITHUB_TOKEN for authenticated Git tag pushes.',
+);
+assert(
+  !/\bGH_TOKEN:/.test(releaseWorkflow),
+  'Do not pass github.token as GH_TOKEN: Semantic Release requires the x-access-token prefix selected by GITHUB_TOKEN.',
+);
 
 assert(
   releaseConfig.tagFormat === 'v${version}',
@@ -73,6 +81,22 @@ assert(
 assert(
   npmPlugin[1].tarballDir === 'release-artifacts',
   'Semantic Release must retain the exact npm tarball for validation and GitHub Releases.',
+);
+
+const githubPlugin = releaseConfig.plugins.find(
+  (entry) => Array.isArray(entry) && entry[0] === '@semantic-release/github',
+);
+assert(
+  githubPlugin !== undefined,
+  'Missing @semantic-release/github configuration.',
+);
+assert(
+  githubPlugin[1].failCommentCondition === false,
+  'Release failures must not create GitHub issues as a secondary failure path.',
+);
+assert(
+  githubPlugin[1].releasedLabels === false,
+  'Releases must not depend on repository-specific labels.',
 );
 
 const analyzerOptions = releaseConfig.plugins.find(


### PR DESCRIPTION
## Root cause

The failed Release job never reached npm Trusted Publishing. Semantic Release stopped during its Git push permission probe:

```text
git push --dry-run ... HEAD:master
remote: Invalid username or token
EGITNOPERMISSION
```

The workflow passed `github.token` as `GH_TOKEN`. Semantic Release accepts that variable for GitHub API calls, but its Git transport only adds GitHub's required `x-access-token:` Basic Auth prefix when the credential is provided as `GITHUB_TOKEN`.

The secondary failure came from `@semantic-release/github` attempting to create a release-failure issue with the repository-missing `semantic-release` label, masking the original error with an HTTP 422.

## Fix

- pass the scoped workflow token as `GITHUB_TOKEN`
- keep checkout credentials disabled; Semantic Release now builds the correctly prefixed ephemeral Git credential itself
- disable automatic failure-issue creation
- disable repository-label-dependent release labeling
- extend the automation policy validator so this exact token regression and label dependency cannot return

## Security

No PAT or long-lived GitHub credential is introduced. The release job still uses the job-scoped `github.token` with `contents: write`; npm publication remains OIDC-only.

## Validation

- `npm run format`
- `npm run lint`
- `npm run validate:automation`
- `git diff --check`
- focused local validation completed; remote final Git tree: `d23ef15b73f58f1c47af0fe6ce3da3d981c8886d`\n- preserves the newer `package-lock.json` already present on `master`

After merge and green CI, Semantic Release will retry the pending breaking release and should calculate `20.0.0`.
