### PR TITLE
ci: align automation with the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main]
   push:
-    branches: [main, master]
+    branches: [main]
   schedule:
     - cron: '17 04 * * 1'
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
-    branches: [main, master]
+    branches: [main]
 
 permissions: {}
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -120,7 +120,7 @@ Do not infer the next version solely from the Angular major. The package peer ra
 
 ## Release process
 
-Every successful CI run for a push to the repository's actual default branch hands the exact validated commit to the **Release** workflow. With branch protection requiring pull requests, this means a merge to `main` (or the current `master` default) is the only normal release entry point. Direct pushes must be disabled in repository rules.
+Every successful CI run for a push to the repository's `main` default branch hands the exact validated commit to the **Release** workflow. With branch protection requiring pull requests, a merge to `main` is the only normal release entry point. Direct pushes must be disabled in repository rules.
 
 Semantic Release then:
 
@@ -148,7 +148,7 @@ The workflow intentionally uses a GitHub-hosted runner, npm `>=11.5.1`, Node `>=
 
 Protect the default branch with pull requests, required approvals, resolved conversations, and these required checks: both `Validate` jobs, all three `Consumer` jobs, `End-to-end (Chrome)`, `Dependency review`, and `CodeQL (JavaScript/TypeScript)`. Require a linear history or squash merges, block force pushes and deletions, and prevent bypass/direct pushes. Protect the `v*` tag namespace as well, while allowing only the Release workflow's GitHub Actions identity to create release tags. Keep pull-request titles in Conventional Commit form because a squash merge uses that title as release input.
 
-The workflows accept `main` and `master` during branch migration, but publication always compares against `github.event.repository.default_branch`. Rename the default branch separately if `main` is the desired canonical name, then update `nx.json`, documentation links, and branch rules in the same administrative migration.
+The workflows target `main`, and publication additionally compares against `github.event.repository.default_branch` before receiving write or OIDC permissions. Keep `nx.json`, documentation links, and repository rules aligned with that branch.
 
 ### Verify a publication
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@ramiz4%2Fngx-multi-level-push-menu.svg)](https://www.npmjs.com/package/@ramiz4/ngx-multi-level-push-menu)
 [![CI](https://github.com/ramiz4/ngx-multi-level-push-menu/actions/workflows/ci.yml/badge.svg)](https://github.com/ramiz4/ngx-multi-level-push-menu/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/LICENSE)
 
 Accessible, responsive, SSR-safe multi-level push navigation for Angular. The library is standalone-first, has no icon or animation dependency, and still supports existing NgModule applications.
 
@@ -394,14 +394,14 @@ npm run build:app
 npm run validate          # format, lint, CI tests, library and example builds
 ```
 
-See [CONTRIBUTING.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/CONTRIBUTING.md) for the contributor workflow, [MAINTENANCE.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/MAINTENANCE.md) for releases, [MIGRATION.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/MIGRATION.md) for upgrading, and [CHANGELOG.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/CHANGELOG.md) for notable changes.
+See [CONTRIBUTING.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/CONTRIBUTING.md) for the contributor workflow, [MAINTENANCE.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/MAINTENANCE.md) for releases, [MIGRATION.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/MIGRATION.md) for upgrading, and [CHANGELOG.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/CHANGELOG.md) for notable changes.
 
 ## Support and security
 
 - Bugs and feature requests: [GitHub Issues](https://github.com/ramiz4/ngx-multi-level-push-menu/issues)
-- Usage help: [SUPPORT.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/SUPPORT.md)
-- Security reports: follow [SECURITY.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/SECURITY.md); do not open a public issue for a suspected vulnerability
+- Usage help: [SUPPORT.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/SUPPORT.md)
+- Security reports: follow [SECURITY.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/SECURITY.md); do not open a public issue for a suspected vulnerability
 
 ## License
 
-[MIT](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/LICENSE) © Ramiz Loki
+[MIT](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/LICENSE) © Ramiz Loki

--- a/libs/ngx-multi-level-push-menu/README.md
+++ b/libs/ngx-multi-level-push-menu/README.md
@@ -4,7 +4,7 @@
 
 [![npm version](https://badge.fury.io/js/@ramiz4%2Fngx-multi-level-push-menu.svg)](https://www.npmjs.com/package/@ramiz4/ngx-multi-level-push-menu)
 [![CI](https://github.com/ramiz4/ngx-multi-level-push-menu/actions/workflows/ci.yml/badge.svg)](https://github.com/ramiz4/ngx-multi-level-push-menu/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/LICENSE)
 
 Accessible, responsive, SSR-safe multi-level push navigation for Angular. The library is standalone-first, has no icon or animation dependency, and still supports existing NgModule applications.
 
@@ -396,14 +396,14 @@ npm run build:app
 npm run validate          # format, lint, CI tests, library and example builds
 ```
 
-See [CONTRIBUTING.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/CONTRIBUTING.md) for the contributor workflow, [MAINTENANCE.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/MAINTENANCE.md) for releases, [MIGRATION.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/MIGRATION.md) for upgrading, and [CHANGELOG.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/CHANGELOG.md) for notable changes.
+See [CONTRIBUTING.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/CONTRIBUTING.md) for the contributor workflow, [MAINTENANCE.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/MAINTENANCE.md) for releases, [MIGRATION.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/MIGRATION.md) for upgrading, and [CHANGELOG.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/CHANGELOG.md) for notable changes.
 
 ## Support and security
 
 - Bugs and feature requests: [GitHub Issues](https://github.com/ramiz4/ngx-multi-level-push-menu/issues)
-- Usage help: [SUPPORT.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/SUPPORT.md)
-- Security reports: follow [SECURITY.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/SECURITY.md); do not open a public issue for a suspected vulnerability
+- Usage help: [SUPPORT.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/SUPPORT.md)
+- Security reports: follow [SECURITY.md](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/SECURITY.md); do not open a public issue for a suspected vulnerability
 
 ## License
 
-[MIT](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/master/LICENSE) © Ramiz Loki
+[MIT](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/LICENSE) © Ramiz Loki

--- a/nx.json
+++ b/nx.json
@@ -79,7 +79,7 @@
     }
   },
   "useInferencePlugins": true,
-  "defaultBase": "master",
+  "defaultBase": "main",
   "plugins": [
     {
       "plugin": "@nx/eslint/plugin",

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,4 +1,4 @@
-const releaseBranch = process.env.RELEASE_BRANCH || 'master';
+const releaseBranch = process.env.RELEASE_BRANCH || 'main';
 
 export default {
   branches: [releaseBranch],

--- a/tools/scripts/validate-automation.mjs
+++ b/tools/scripts/validate-automation.mjs
@@ -33,6 +33,10 @@ for (const { content, name } of workflows) {
 }
 
 const allWorkflowContent = workflows.map(({ content }) => content).join('\n');
+assert(
+  !/\bmaster\b/.test(allWorkflowContent),
+  'GitHub workflows must target the canonical main branch only.',
+);
 for (const forbiddenCredential of ['secrets.NPM_TOKEN', 'secrets.GH_PAT']) {
   assert(
     !allWorkflowContent.includes(forbiddenCredential),
@@ -64,6 +68,18 @@ assert(
 assert(
   releaseConfig.tagFormat === 'v${version}',
   'Semantic Release tags must use v${version}.',
+);
+assert(
+  releaseConfig.branches.length === 1 && releaseConfig.branches[0] === 'main',
+  'Semantic Release must default to the canonical main branch.',
+);
+
+const nxConfig = JSON.parse(
+  readFileSync(resolve(workspaceRoot, 'nx.json'), 'utf8'),
+);
+assert(
+  nxConfig.defaultBase === 'main',
+  'Nx affected commands must compare against the canonical main branch.',
 );
 for (const pluginEntry of releaseConfig.plugins) {
   const pluginName = Array.isArray(pluginEntry) ? pluginEntry[0] : pluginEntry;


### PR DESCRIPTION
## Summary

- targets only the canonical `main` branch in CI and Release triggers
- changes Nx's `defaultBase` to `main`
- changes the local Semantic Release fallback to `main`
- updates canonical and packaged README links from `master` to `main`
- removes completed branch-migration wording from the maintenance guide
- extends the automation validator to reject future `master` regressions and require the aligned Nx/Semantic Release defaults

## Release behavior

This is a `ci:`-only change. After merge, CI and the Release workflow will run on `main`, but Semantic Release should correctly finish without publishing a new npm version. The current npm `latest` remains `20.0.0`.

## Validation

- repository default branch verified as `main`
- no remaining `master` references in workflows, Nx, release configuration, or maintained documentation
- `npm run format`
- `npm run lint`
- `npm run validate:automation`
- `git diff --check`
- remote Git tree: `0bb777b4c91196f19c3b71d815075f6df82020e0`
