### PR TITLE
fix: resolve base-path navigation and publish interactive demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,14 @@ jobs:
       - name: Build example application
         run: npm run build:app
 
+      - name: Validate GitHub Pages artifact
+        if: matrix.node-version == '22.x'
+        env:
+          BASE_HREF: /ngx-multi-level-push-menu/
+        run: |
+          npm run build:app -- --configuration=production --base-href "$BASE_HREF"
+          npm run prepare:pages
+
       - name: Validate distributable package
         run: |
           node tools/scripts/validate-package.mjs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,97 @@
+name: Demo
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  CI: true
+  NX_DAEMON: false
+  NX_ISOLATE_PLUGINS: false
+  NPM_VERSION: 11.18.0
+
+jobs:
+  build:
+    name: Build validated demo
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pages: read
+    env:
+      CYPRESS_INSTALL_BINARY: '0'
+
+    steps:
+      - name: Checkout the validated commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.22.3
+          package-manager-cache: false
+
+      - name: Use the pinned npm version
+        run: npm install --global npm@"$NPM_VERSION" --ignore-scripts
+
+      - name: Verify the deployment commit
+        env:
+          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
+          DEPLOY_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$DEPLOY_SHA"
+          git fetch --no-tags origin "$DEPLOY_BRANCH"
+          git merge-base --is-ancestor HEAD "origin/$DEPLOY_BRANCH"
+
+      - name: Install dependencies without a shared deployment cache
+        run: npm ci
+
+      - name: Build and validate the Pages artifact
+        env:
+          BASE_HREF: ${{ steps.pages.outputs.base_path }}/
+        run: |
+          npm run build:app -- --configuration=production --base-href "$BASE_HREF"
+          npm run prepare:pages
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: dist/apps/multi-level-push-menu-example
+
+  deploy:
+    name: Deploy demo
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -144,6 +144,18 @@ Configure this before merging the release automation:
 
 The workflow intentionally uses a GitHub-hosted runner, npm `>=11.5.1`, Node `>=22.14`, `id-token: write`, and no shared package-manager cache. These are requirements of npm Trusted Publishing, not optional repository conventions.
 
+### Demo deployment
+
+The **Demo** workflow runs independently from the npm release after the same successful `main` CI. It checks out the exact validated commit, derives the site base path from GitHub Pages, builds the production example, validates the artifact, and deploys it to the protected `github-pages` environment. A copied `404.html` lets Angular Router restore deep links on GitHub Pages.
+
+One-time repository setup:
+
+1. In **Settings → Pages → Build and deployment**, set **Source** to **GitHub Actions**.
+2. In **Settings → Environments → github-pages**, allow deployments from `main`. Do not add a required reviewer if deployment must remain automatic.
+3. Merge a pull request and verify both `https://ramiz4.github.io/ngx-multi-level-push-menu/` and one routed deep link.
+
+Do not deploy CI artifacts produced by pull requests. The privileged workflow intentionally rebuilds the trusted `main` commit without a shared package-manager cache. The Pages workflow uses `actions/configure-pages` for the base path so the same build also remains valid if a custom domain is introduced later.
+
 ### Required repository rules
 
 Protect the default branch with pull requests, required approvals, resolved conversations, and these required checks: both `Validate` jobs, all three `Consumer` jobs, `End-to-end (Chrome)`, `Dependency review`, and `CodeQL (JavaScript/TypeScript)`. Require a linear history or squash merges, block force pushes and deletions, and prevent bypass/direct pushes. Protect the `v*` tag namespace as well, while allowing only the Release workflow's GitHub Actions identity to create release tags. Keep pull-request titles in Conventional Commit form because a squash merge uses that title as release input.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 [![npm version](https://badge.fury.io/js/@ramiz4%2Fngx-multi-level-push-menu.svg)](https://www.npmjs.com/package/@ramiz4/ngx-multi-level-push-menu)
 [![CI](https://github.com/ramiz4/ngx-multi-level-push-menu/actions/workflows/ci.yml/badge.svg)](https://github.com/ramiz4/ngx-multi-level-push-menu/actions/workflows/ci.yml)
+[![Live demo](https://img.shields.io/badge/live_demo-open-18a47e)](https://ramiz4.github.io/ngx-multi-level-push-menu/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/LICENSE)
 
 Accessible, responsive, SSR-safe multi-level push navigation for Angular. The library is standalone-first, has no icon or animation dependency, and still supports existing NgModule applications.
+
+[Open the interactive demo](https://ramiz4.github.io/ngx-multi-level-push-menu/) to try every public input, targeted service commands, typed output events, RTL, theming, and copy-ready setup examples.
 
 ## Why use it?
 
@@ -164,6 +167,7 @@ The visible-label fallback order is `name`, `title`, `id`, then `Untitled item`.
 ### Routing behavior
 
 - Same-context internal links use the optional Angular `Router` when one is available.
+- Rendered internal anchor URLs include the application's base href, so open-in-new-tab and modified clicks also work from subpath deployments.
 - External, protocol-relative, fragment, modified-click, and non-`_self` links keep native anchor behavior.
 - `target="_blank"` is protected with `rel="noopener noreferrer"` unless `rel` is supplied.
 - Set `closeOnNavigation` to collapse after native navigation starts or Angular Router navigation succeeds.

--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -108,4 +108,62 @@ describe('multi-level push menu playground', () => {
       .find('.ngx-push-menu__navigation')
       .should('have.css', 'background-color', 'rgb(21, 22, 46)');
   });
+
+  it('provides copy-ready, complete quick-start examples', () => {
+    cy.window().then((window) => {
+      const writeText = cy.stub().resolves();
+      Object.defineProperty(window.navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+      cy.wrap(writeText).as('writeText');
+    });
+
+    cy.getByTestId('snippet-template').click();
+    cy.get('[role="tabpanel"] code').should(
+      'contain.text',
+      '<ngx-multi-level-push-menu',
+    );
+    cy.getByTestId('copy-snippet').click();
+    cy.getByTestId('copy-snippet').should('have.text', 'Copied');
+    cy.get('@writeText').should(
+      'have.been.calledWithMatch',
+      '<ngx-multi-level-push-menu',
+    );
+  });
+
+  it('demonstrates targeted service control and configuration reset', () => {
+    cy.getByTestId('mode-overlap').click();
+    cy.getByTestId('toggle-direction').click();
+    cy.getByTestId('toggle-close-on-navigation').click();
+
+    cy.getByTestId('service-analytics').click();
+    getActiveLevel().should('have.attr', 'aria-label', 'Analytics');
+
+    cy.getByTestId('reset-playground').click();
+    getMenu()
+      .should('have.attr', 'data-mode', 'cover')
+      .and('have.attr', 'data-direction', 'ltr')
+      .and('have.attr', 'data-theme', 'aurora');
+    cy.getByTestId('toggle-close-on-navigation').should(
+      'have.attr',
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('keeps the complete demo usable without horizontal overflow on mobile', () => {
+    cy.viewport(375, 812);
+    cy.visit('/');
+
+    cy.get('h1').should('be.visible');
+    cy.getByTestId('snippet-install').click();
+    cy.get('[role="tabpanel"]').scrollIntoView();
+    cy.get('[role="tabpanel"]').should('be.visible');
+    cy.window().then((window) => {
+      expect(window.document.documentElement.scrollWidth).to.be.at.most(
+        window.innerWidth,
+      );
+    });
+  });
 });

--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -125,7 +125,7 @@ describe('multi-level push menu playground', () => {
       '<ngx-multi-level-push-menu',
     );
     cy.getByTestId('copy-snippet').click();
-    cy.getByTestId('copy-snippet').should('have.text', 'Copied');
+    cy.getByTestId('copy-snippet').should('contain.text', 'Copied');
     cy.get('@writeText').should(
       'have.been.calledWithMatch',
       '<ngx-multi-level-push-menu',
@@ -156,6 +156,8 @@ describe('multi-level push menu playground', () => {
     cy.viewport(375, 812);
     cy.visit('/');
 
+    getActiveLevel().find('[data-menu-toggle]').click();
+    getMenu().should('have.attr', 'data-collapsed', 'true');
     cy.get('h1').should('be.visible');
     cy.getByTestId('snippet-install').click();
     cy.get('[role="tabpanel"]').scrollIntoView();

--- a/apps/multi-level-push-menu-example/src/app/app.component.html
+++ b/apps/multi-level-push-menu-example/src/app/app.component.html
@@ -14,18 +14,32 @@
   (groupActivate)="onGroupActivate($event)"
   (levelChange)="onLevelChange($event)"
 >
-  <main class="demo-shell">
+  <a class="demo-skip-link" href="#demo-main">Skip to demo content</a>
+
+  <main id="demo-main" class="demo-shell">
     <header class="demo-topbar">
-      <a class="demo-brand" href="/home" aria-label="Nexus demo home">
-        <span class="demo-brand__mark" aria-hidden="true">N</span>
+      <a
+        class="demo-brand"
+        routerLink="/"
+        aria-label="ngx-multi-level-push-menu demo home"
+      >
+        <span class="demo-brand__mark" aria-hidden="true">ngx</span>
         <span>
-          <strong>Nexus UI</strong>
-          <small>Push menu playground</small>
+          <strong>ngx push menu</strong>
+          <small>Interactive Angular demo</small>
         </span>
       </a>
 
-      <div class="demo-topbar__actions" aria-label="Menu state controls">
-        <span class="demo-state-dot" [class.is-active]="!collapsed"></span>
+      <div
+        class="demo-topbar__actions"
+        role="group"
+        aria-label="Menu state controls"
+      >
+        <span
+          class="demo-state-dot"
+          aria-hidden="true"
+          [class.is-active]="!collapsed"
+        ></span>
         <span data-testid="menu-state">
           {{ collapsed ? 'Collapsed' : 'Expanded' }}
         </span>
@@ -55,15 +69,42 @@
     <div class="demo-content">
       <section class="demo-hero" aria-labelledby="demo-heading">
         <div>
-          <p class="demo-eyebrow">Angular navigation, reimagined</p>
-          <h1 id="demo-heading">Deep navigation.<br />Delightfully simple.</h1>
+          <p class="demo-eyebrow">Live Angular 20–22 playground</p>
+          <h1 id="demo-heading">
+            Deep navigation.<br />Shallow learning curve.
+          </h1>
           <p class="demo-lead">
-            A provider-free, accessible push menu with typed events, responsive
-            motion and a tiny integration surface.
+            Accessible, typed multi-level navigation with a standalone-first
+            API, no required providers and no design-system lock-in.
           </p>
+
+          <div class="demo-hero__actions">
+            <button
+              type="button"
+              class="demo-button demo-button--primary"
+              data-testid="copy-install"
+              (click)="copySnippet(installSnippet)"
+            >
+              {{
+                copiedSnippetId() === 'install'
+                  ? 'Install command copied'
+                  : 'Copy npm install'
+              }}
+            </button>
+            <a
+              class="demo-button demo-button--secondary"
+              [href]="repositoryUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View source <span aria-hidden="true">&#8599;</span>
+            </a>
+          </div>
+
           <div class="demo-pills" aria-label="Library highlights">
             <span>Standalone</span>
             <span>Typed outputs</span>
+            <span>SSR-safe</span>
             <span>RTL ready</span>
             <span>Zero icon dependencies</span>
           </div>
@@ -79,13 +120,88 @@
         </div>
       </section>
 
+      <section
+        id="quick-start"
+        class="demo-quick-start"
+        aria-labelledby="quick-start-heading"
+      >
+        <div class="demo-section-heading">
+          <div>
+            <p class="demo-eyebrow">Copy, understand, ship</p>
+            <h2 id="quick-start-heading">Four steps to production</h2>
+          </div>
+          <p>
+            Every example below is complete, typed and ready to adapt in a
+            standalone Angular application.
+          </p>
+        </div>
+
+        <div
+          class="demo-snippet-tabs"
+          role="tablist"
+          aria-label="Quick start code examples"
+        >
+          @for (snippet of snippets; track snippet.id) {
+            <button
+              type="button"
+              role="tab"
+              [id]="'snippet-tab-' + snippet.id"
+              [attr.aria-controls]="'snippet-panel-' + snippet.id"
+              [attr.aria-selected]="activeSnippetId() === snippet.id"
+              [attr.tabindex]="activeSnippetId() === snippet.id ? 0 : -1"
+              [class.is-selected]="activeSnippetId() === snippet.id"
+              [attr.data-testid]="'snippet-' + snippet.id"
+              (click)="selectSnippet(snippet.id)"
+            >
+              <span>{{ snippet.step }}</span>
+              {{ snippet.title }}
+            </button>
+          }
+        </div>
+
+        @let snippet = activeSnippet();
+        <article
+          class="demo-snippet"
+          role="tabpanel"
+          [id]="'snippet-panel-' + snippet.id"
+          [attr.aria-labelledby]="'snippet-tab-' + snippet.id"
+        >
+          <header class="demo-snippet__header">
+            <div>
+              <span>{{ snippet.fileName }}</span>
+              <p>{{ snippet.description }}</p>
+            </div>
+            <button
+              type="button"
+              class="demo-copy-button"
+              data-testid="copy-snippet"
+              [attr.aria-label]="'Copy ' + snippet.title + ' code'"
+              (click)="copySnippet(snippet)"
+            >
+              {{ copiedSnippetId() === snippet.id ? 'Copied' : 'Copy' }}
+            </button>
+          </header>
+          <pre tabindex="0"><code
+            [attr.data-language]="snippet.language"
+            [textContent]="snippet.code"
+          ></code></pre>
+        </article>
+
+        <p class="demo-visually-hidden" role="status" aria-live="polite">
+          {{ copyStatus() }}
+        </p>
+      </section>
+
       <section class="demo-playground" aria-labelledby="playground-heading">
         <div class="demo-section-heading">
           <div>
-            <p class="demo-eyebrow">Live configuration</p>
+            <p class="demo-eyebrow">Live public API</p>
             <h2 id="playground-heading">Make it yours</h2>
           </div>
-          <p>Every control updates the component through public inputs.</p>
+          <p>
+            Use the menu on this page while every control updates its public
+            inputs in real time.
+          </p>
         </div>
 
         <div class="demo-toolbar">
@@ -140,6 +256,81 @@
           </div>
         </div>
 
+        <div class="demo-behaviors">
+          <label class="demo-width-control">
+            <span>
+              Menu width
+              <output>{{ options.menuWidth }}px</output>
+            </span>
+            <input
+              type="range"
+              min="280"
+              max="380"
+              step="20"
+              [value]="options.menuWidth"
+              (input)="setMenuWidth($event)"
+            />
+          </label>
+
+          <button
+            type="button"
+            class="demo-behavior-toggle"
+            data-testid="toggle-close-on-navigation"
+            [attr.aria-pressed]="options.closeOnNavigation"
+            (click)="toggleCloseOnNavigation()"
+          >
+            <span>Close after route</span>
+            <strong>{{ options.closeOnNavigation ? 'On' : 'Off' }}</strong>
+          </button>
+
+          <button
+            type="button"
+            class="demo-behavior-toggle"
+            data-testid="toggle-preserve-level"
+            [attr.aria-pressed]="options.preserveActiveLevelOnCollapse"
+            (click)="togglePreserveLevel()"
+          >
+            <span>Preserve active level</span>
+            <strong>
+              {{ options.preserveActiveLevelOnCollapse ? 'On' : 'Off' }}
+            </strong>
+          </button>
+
+          <button
+            type="button"
+            class="demo-reset-button"
+            data-testid="reset-playground"
+            (click)="resetPlayground()"
+          >
+            Reset
+          </button>
+        </div>
+
+        <div class="demo-command-bar">
+          <div>
+            <small>Targeted service commands</small>
+            <strong>Control <code>#nexus-demo-menu</code></strong>
+          </div>
+          <div role="group" aria-label="Multi-level push menu service commands">
+            <button type="button" (click)="runServiceCommand('open')">
+              Open
+            </button>
+            <button
+              type="button"
+              data-testid="service-analytics"
+              (click)="runServiceCommand('analytics')"
+            >
+              Go to Analytics
+            </button>
+            <button type="button" (click)="runServiceCommand('back')">
+              Back
+            </button>
+            <button type="button" (click)="runServiceCommand('close')">
+              Close
+            </button>
+          </div>
+        </div>
+
         <div class="demo-event-card" aria-live="polite">
           <div>
             <span class="demo-event-card__icon" aria-hidden="true"
@@ -171,7 +362,20 @@
 
       <footer class="demo-footer">
         <span>Built for Angular teams who care about the details.</span>
-        <span>Keyboard &bull; Touch &bull; Mouse</span>
+        <nav aria-label="Project links">
+          <a
+            [href]="repositoryUrl + '#readme'"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Documentation</a
+          >
+          <a [href]="packageUrl" target="_blank" rel="noopener noreferrer"
+            >npm</a
+          >
+          <a [href]="repositoryUrl" target="_blank" rel="noopener noreferrer"
+            >GitHub</a
+          >
+        </nav>
       </footer>
     </div>
   </main>

--- a/apps/multi-level-push-menu-example/src/app/app.component.spec.ts
+++ b/apps/multi-level-push-menu-example/src/app/app.component.spec.ts
@@ -81,4 +81,37 @@ describe('AppComponent', () => {
     expect(menu?.getAttribute('data-collapsed')).toBe('true');
     expect(component.lastEvent.label).toBe('Menu collapsed');
   });
+
+  it('switches between complete quick-start snippets', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const component = fixture.componentInstance;
+
+    component.selectSnippet('template');
+    fixture.detectChanges();
+
+    expect(component.activeSnippet().id).toBe('template');
+    expect(
+      (fixture.nativeElement as HTMLElement).querySelector(
+        '[role="tabpanel"] code',
+      )?.textContent,
+    ).toContain('<ngx-multi-level-push-menu');
+  });
+
+  it('resets all live configuration through one public-options update', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const component = fixture.componentInstance;
+    component.setMode('overlap');
+    component.toggleDirection();
+    component.toggleTheme();
+    component.toggleCloseOnNavigation();
+
+    component.resetPlayground();
+
+    expect(component.options.mode).toBe('cover');
+    expect(component.options.direction).toBe('ltr');
+    expect(component.options.closeOnNavigation).toBe(false);
+    expect(component.theme).toBe('aurora');
+    expect(component.collapsed).toBe(false);
+    expect(component.lastEvent.label).toBe('Playground reset');
+  });
 });

--- a/apps/multi-level-push-menu-example/src/app/app.component.ts
+++ b/apps/multi-level-push-menu-example/src/app/app.component.ts
@@ -1,11 +1,20 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { DOCUMENT } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { RouterLink, RouterOutlet } from '@angular/router';
 import {
   MenuActivationEvent,
   MultiLevelPushMenuComponent,
   MultiLevelPushMenuItem,
   MultiLevelPushMenuOptions,
+  MultiLevelPushMenuService,
 } from '@ramiz4/ngx-multi-level-push-menu';
+import { DEMO_SNIPPETS, DemoSnippet, DemoSnippetId } from './demo-snippets';
 
 type DemoEventKind = 'ready' | 'group' | 'item' | 'state';
 type DemoTheme = 'aurora' | 'midnight';
@@ -42,12 +51,30 @@ const ICONS = {
 
 @Component({
   selector: 'ramiz4-root',
-  imports: [RouterOutlet, MultiLevelPushMenuComponent],
+  imports: [RouterLink, RouterOutlet, MultiLevelPushMenuComponent],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {
+  private readonly document = inject(DOCUMENT);
+  private readonly menuService = inject(MultiLevelPushMenuService);
+
+  readonly repositoryUrl =
+    'https://github.com/ramiz4/ngx-multi-level-push-menu';
+  readonly packageUrl =
+    'https://www.npmjs.com/package/@ramiz4/ngx-multi-level-push-menu';
+  readonly snippets = DEMO_SNIPPETS;
+  readonly installSnippet = DEMO_SNIPPETS[0];
+  readonly activeSnippetId = signal<DemoSnippetId>('component');
+  readonly copiedSnippetId = signal<DemoSnippetId | null>(null);
+  readonly copyStatus = signal('');
+  readonly activeSnippet = computed(
+    () =>
+      this.snippets.find((snippet) => snippet.id === this.activeSnippetId()) ??
+      this.snippets[0],
+  );
+
   readonly menuItems: readonly MultiLevelPushMenuItem<DemoMenuData>[] = [
     {
       id: 'home',
@@ -183,21 +210,7 @@ export class AppComponent {
     },
   ];
 
-  options = new MultiLevelPushMenuOptions({
-    title: 'Nexus',
-    titleIcon: ICONS.brand,
-    menuID: 'nexus-demo-menu',
-    ariaLabel: 'Nexus product navigation',
-    menuWidth: 320,
-    menuHeight: '100dvh',
-    overlapWidth: 52,
-    mode: 'cover',
-    direction: 'ltr',
-    backText: 'Back',
-    closeOnNavigation: false,
-    preserveActiveLevelOnCollapse: true,
-    animationDuration: 240,
-  });
+  options = this.createDefaultOptions();
 
   collapsed = false;
   theme: DemoTheme = 'aurora';
@@ -242,11 +255,129 @@ export class AppComponent {
     this.recordActivation('group', event);
   }
 
+  setMenuWidth(event: Event): void {
+    const input = event.target;
+    if (!(input instanceof HTMLInputElement)) return;
+
+    this.updateOptions({ menuWidth: input.valueAsNumber });
+    this.recordState(`Menu width set to ${input.valueAsNumber}px`);
+  }
+
+  toggleCloseOnNavigation(): void {
+    const closeOnNavigation = !this.options.closeOnNavigation;
+    this.updateOptions({ closeOnNavigation });
+    this.recordState(
+      `Close on navigation ${closeOnNavigation ? 'enabled' : 'disabled'}`,
+    );
+  }
+
+  togglePreserveLevel(): void {
+    const preserveActiveLevelOnCollapse =
+      !this.options.preserveActiveLevelOnCollapse;
+    this.updateOptions({ preserveActiveLevelOnCollapse });
+    this.recordState(
+      `Preserve active level ${preserveActiveLevelOnCollapse ? 'enabled' : 'disabled'}`,
+    );
+  }
+
+  resetPlayground(): void {
+    this.options = this.createDefaultOptions();
+    this.theme = 'aurora';
+    this.collapsed = false;
+    this.recordState('Playground reset');
+  }
+
+  runServiceCommand(command: 'open' | 'analytics' | 'back' | 'close'): void {
+    const targetId = this.options.menuID;
+
+    switch (command) {
+      case 'open':
+        this.menuService.openMenu(targetId);
+        break;
+      case 'analytics':
+        this.menuService.openMenu(targetId);
+        this.menuService.navigateToLevel('analytics', targetId);
+        break;
+      case 'back':
+        this.menuService.goBack(targetId);
+        break;
+      case 'close':
+        this.menuService.closeMenu(targetId);
+        break;
+    }
+
+    this.recordState(`Service command: ${command}`);
+  }
+
+  selectSnippet(id: DemoSnippetId): void {
+    this.activeSnippetId.set(id);
+    this.copiedSnippetId.set(null);
+  }
+
+  async copySnippet(snippet: DemoSnippet): Promise<void> {
+    let copied = false;
+
+    try {
+      const clipboard = this.document.defaultView?.navigator.clipboard;
+      if (clipboard) {
+        await clipboard.writeText(snippet.code);
+        copied = true;
+      }
+    } catch {
+      // The DOM fallback below also supports browsers that deny Clipboard API.
+    }
+
+    if (!copied) copied = this.copyWithDomFallback(snippet.code);
+
+    this.copiedSnippetId.set(copied ? snippet.id : null);
+    this.copyStatus.set(
+      copied
+        ? `${snippet.title} copied to the clipboard.`
+        : 'Copy was blocked. Select the code and copy it manually.',
+    );
+  }
+
   private updateOptions(patch: Partial<MultiLevelPushMenuOptions>): void {
     this.options = new MultiLevelPushMenuOptions({
       ...this.options,
       ...patch,
     });
+  }
+
+  private createDefaultOptions(): MultiLevelPushMenuOptions {
+    return new MultiLevelPushMenuOptions({
+      title: 'Nexus',
+      titleIcon: ICONS.brand,
+      menuID: 'nexus-demo-menu',
+      ariaLabel: 'Nexus product navigation',
+      menuWidth: 320,
+      menuHeight: '100dvh',
+      overlapWidth: 52,
+      mode: 'cover',
+      direction: 'ltr',
+      backText: 'Back',
+      closeOnNavigation: false,
+      preserveActiveLevelOnCollapse: true,
+      animationDuration: 240,
+    });
+  }
+
+  private copyWithDomFallback(text: string): boolean {
+    const textarea = this.document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    this.document.body.append(textarea);
+    textarea.select();
+
+    try {
+      return this.document.execCommand('copy');
+    } catch {
+      return false;
+    } finally {
+      textarea.remove();
+    }
   }
 
   private recordActivation(

--- a/apps/multi-level-push-menu-example/src/app/demo-snippets.ts
+++ b/apps/multi-level-push-menu-example/src/app/demo-snippets.ts
@@ -1,0 +1,149 @@
+export type DemoSnippetId = 'install' | 'component' | 'template' | 'styles';
+
+export type DemoSnippetLanguage = 'shell' | 'typescript' | 'html' | 'scss';
+
+export interface DemoSnippet {
+  readonly id: DemoSnippetId;
+  readonly step: 1 | 2 | 3 | 4;
+  readonly title: string;
+  readonly description: string;
+  readonly language: DemoSnippetLanguage;
+  readonly fileName: string;
+  readonly code: string;
+}
+
+export const DEMO_SNIPPETS = [
+  {
+    id: 'install',
+    step: 1,
+    title: 'Install the package',
+    description:
+      'No animation module, icon library, provider, or global stylesheet is required.',
+    language: 'shell',
+    fileName: 'Terminal',
+    code: 'npm install @ramiz4/ngx-multi-level-push-menu',
+  },
+  {
+    id: 'component',
+    step: 2,
+    title: 'Define a typed menu',
+    description:
+      'Import the standalone component and keep application metadata type-safe.',
+    language: 'typescript',
+    fileName: 'app-shell.component.ts',
+    code: `import {
+  ChangeDetectionStrategy,
+  Component,
+  signal,
+} from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+import {
+  MenuActivationEvent,
+  MultiLevelPushMenuComponent,
+  MultiLevelPushMenuItem,
+  MultiLevelPushMenuOptions,
+} from '@ramiz4/ngx-multi-level-push-menu';
+
+interface NavMetadata {
+  readonly analyticsId: string;
+  readonly requiresAuth?: boolean;
+}
+
+@Component({
+  selector: 'app-shell',
+  imports: [MultiLevelPushMenuComponent, RouterOutlet],
+  templateUrl: './app-shell.component.html',
+  styleUrl: './app-shell.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AppShellComponent {
+  readonly menu: readonly MultiLevelPushMenuItem<NavMetadata>[] = [
+    {
+      id: 'dashboard',
+      name: 'Dashboard',
+      link: '/dashboard',
+      data: { analyticsId: 'nav_dashboard', requiresAuth: true },
+    },
+    {
+      id: 'products',
+      name: 'Products',
+      items: [
+        {
+          id: 'catalog',
+          name: 'Catalog',
+          link: '/products/catalog',
+          data: { analyticsId: 'nav_catalog' },
+        },
+        {
+          id: 'orders',
+          name: 'Orders',
+          link: '/products/orders',
+          data: { analyticsId: 'nav_orders', requiresAuth: true },
+        },
+      ],
+    },
+  ];
+
+  readonly options = new MultiLevelPushMenuOptions({
+    title: 'Acme',
+    ariaLabel: 'Primary navigation',
+    menuWidth: '19rem',
+    mode: 'cover',
+    closeOnNavigation: true,
+  });
+
+  readonly activePath = signal('No destination selected');
+  collapsed = false;
+
+  onItemActivate(event: MenuActivationEvent<NavMetadata>): void {
+    this.activePath.set(event.path.map((item) => item.name).join(' / '));
+  }
+}`,
+  },
+  {
+    id: 'template',
+    step: 3,
+    title: 'Bind it in the shell',
+    description:
+      'Project routed content into the component and opt into controlled state only when needed.',
+    language: 'html',
+    fileName: 'app-shell.component.html',
+    code: `<ngx-multi-level-push-menu
+  [menu]="menu"
+  [options]="options"
+  [(collapsed)]="collapsed"
+  (itemActivate)="onItemActivate($event)"
+>
+  <router-outlet />
+</ngx-multi-level-push-menu>
+
+<p class="selection" aria-live="polite">{{ activePath() }}</p>`,
+  },
+  {
+    id: 'styles',
+    step: 4,
+    title: 'Size and theme it',
+    description:
+      'The menu inherits your design system through documented CSS custom properties.',
+    language: 'scss',
+    fileName: 'app-shell.component.scss',
+    code: `:host {
+  display: block;
+  height: 100dvh;
+}
+
+ngx-multi-level-push-menu {
+  display: block;
+  height: 100%;
+
+  --ngx-push-menu-background: #0b3d2e;
+  --ngx-push-menu-surface: #115740;
+  --ngx-push-menu-hover: #176b4e;
+  --ngx-push-menu-active: #082d22;
+  --ngx-push-menu-color: #fff;
+  --ngx-push-menu-border: rgb(255 255 255 / 24%);
+  --ngx-push-menu-focus: #a7f3d0;
+  --ngx-push-menu-shadow: 0 0.75rem 2rem rgb(0 0 0 / 30%);
+}`,
+  },
+] as const satisfies readonly DemoSnippet[];

--- a/apps/multi-level-push-menu-example/src/index.html
+++ b/apps/multi-level-push-menu-example/src/index.html
@@ -2,12 +2,30 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Nexus · Angular Push Menu Playground</title>
+    <title>ngx-multi-level-push-menu · Interactive Angular demo</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Interactive playground for ngx-multi-level-push-menu."
+      content="Explore, configure, and copy production-ready examples for the accessible ngx-multi-level-push-menu Angular library."
+    />
+    <meta name="theme-color" content="#0d3835" />
+    <meta
+      property="og:title"
+      content="ngx-multi-level-push-menu · Interactive Angular demo"
+    />
+    <meta
+      property="og:description"
+      content="Try deep navigation, live configuration, typed events, RTL, and copy-ready Angular examples."
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://ramiz4.github.io/ngx-multi-level-push-menu/"
+    />
+    <link
+      rel="canonical"
+      href="https://ramiz4.github.io/ngx-multi-level-push-menu/"
     />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>

--- a/apps/multi-level-push-menu-example/src/styles.scss
+++ b/apps/multi-level-push-menu-example/src/styles.scss
@@ -40,6 +40,35 @@ a:focus-visible {
   outline-offset: 3px;
 }
 
+.demo-skip-link {
+  position: fixed;
+  z-index: 100;
+  top: 0.75rem;
+  left: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.65rem;
+  color: #fff;
+  background: #0d3835;
+  text-decoration: none;
+  transform: translateY(-180%);
+}
+
+.demo-skip-link:focus {
+  transform: translateY(0);
+}
+
+.demo-visually-hidden {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
 .demo-shell {
   min-height: 100%;
   background:
@@ -75,14 +104,16 @@ a:focus-visible {
 
 .demo-brand__mark {
   display: grid;
-  width: 2.25rem;
+  width: 2.65rem;
   height: 2.25rem;
   place-items: center;
   border-radius: 0.75rem;
   color: #effff9;
   background: #0d3835;
   box-shadow: 0 0.5rem 1.25rem rgb(5 58 49 / 20%);
+  font-size: 0.7rem;
   font-weight: 850;
+  letter-spacing: -0.03em;
 }
 
 .demo-brand strong,
@@ -123,8 +154,8 @@ a:focus-visible {
 
 .demo-icon-button {
   display: grid;
-  width: 2.2rem;
-  height: 2.2rem;
+  width: 2.75rem;
+  height: 2.75rem;
   place-items: center;
   border: 1px solid #d6e4df;
   border-radius: 0.7rem;
@@ -183,6 +214,49 @@ a:focus-visible {
   color: #55736d;
   font-size: clamp(1rem, 2vw, 1.2rem);
   line-height: 1.7;
+}
+
+.demo-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.7rem;
+}
+
+.demo-button {
+  display: inline-flex;
+  min-height: 2.85rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.7rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 0.8rem;
+  cursor: pointer;
+  font-size: 0.82rem;
+  font-weight: 780;
+  text-decoration: none;
+}
+
+.demo-button--primary {
+  color: #f1fff9;
+  background: #0d3835;
+  box-shadow: 0 0.75rem 1.8rem rgb(13 56 53 / 18%);
+}
+
+.demo-button--primary:hover {
+  background: #14534b;
+}
+
+.demo-button--secondary {
+  border-color: #cfe1db;
+  color: #174a41;
+  background: rgb(255 255 255 / 75%);
+}
+
+.demo-button--secondary:hover {
+  border-color: #94c8b8;
+  background: #fff;
 }
 
 .demo-pills {
@@ -285,6 +359,133 @@ a:focus-visible {
   backdrop-filter: blur(1rem);
 }
 
+.demo-quick-start {
+  margin-bottom: 1rem;
+  padding: clamp(1.2rem, 3vw, 2.25rem);
+  border: 1px solid rgb(15 79 68 / 10%);
+  border-radius: 1.5rem;
+  background: #eef7f4;
+  box-shadow: 0 1.5rem 4rem rgb(32 77 67 / 6%);
+}
+
+.demo-snippet-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+.demo-snippet-tabs button {
+  display: flex;
+  min-width: 0;
+  min-height: 3.25rem;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.65rem;
+  border: 1px solid #d2e4de;
+  border-radius: 0.8rem;
+  color: #456861;
+  background: rgb(255 255 255 / 68%);
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 750;
+  text-align: left;
+}
+
+.demo-snippet-tabs button:hover,
+.demo-snippet-tabs button.is-selected {
+  border-color: #62b99f;
+  color: #0d4c40;
+  background: #fff;
+}
+
+.demo-snippet-tabs button.is-selected {
+  box-shadow: 0 0.5rem 1.25rem rgb(15 96 75 / 10%);
+}
+
+.demo-snippet-tabs button span {
+  display: grid;
+  flex: 0 0 auto;
+  width: 1.55rem;
+  height: 1.55rem;
+  place-items: center;
+  border-radius: 0.48rem;
+  color: #f2fff9;
+  background: #168665;
+  font-size: 0.68rem;
+}
+
+.demo-snippet {
+  overflow: hidden;
+  margin-top: 0.75rem;
+  border: 1px solid rgb(181 227 213 / 20%);
+  border-radius: 1rem;
+  color: #dffbf1;
+  background: #102d2a;
+  box-shadow: 0 1rem 2.5rem rgb(7 40 35 / 12%);
+}
+
+.demo-snippet__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgb(255 255 255 / 9%);
+  background: rgb(255 255 255 / 3%);
+}
+
+.demo-snippet__header span {
+  color: #9de8cf;
+  font:
+    0.7rem/1.4 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+}
+
+.demo-snippet__header p {
+  margin: 0.2rem 0 0;
+  color: #91b8af;
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.demo-copy-button {
+  min-width: 4.5rem;
+  min-height: 2.75rem;
+  border: 1px solid rgb(168 242 217 / 25%);
+  border-radius: 0.65rem;
+  color: #dffbf1;
+  background: rgb(255 255 255 / 7%);
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.demo-copy-button:hover {
+  border-color: #7ff0ca;
+  background: rgb(127 240 202 / 10%);
+}
+
+.demo-snippet pre {
+  overflow: auto;
+  max-height: 31rem;
+  margin: 0;
+  padding: 1rem;
+  color: #c5f7e6;
+  font:
+    0.74rem/1.65 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  tab-size: 2;
+}
+
+.demo-snippet code {
+  font: inherit;
+}
+
 .demo-section-heading {
   display: flex;
   align-items: end;
@@ -312,6 +513,133 @@ a:focus-visible {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.8rem;
   margin-top: 1.5rem;
+}
+
+.demo-behaviors {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1.4fr) 1fr 1fr auto;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.demo-width-control,
+.demo-behavior-toggle,
+.demo-reset-button {
+  min-height: 4.1rem;
+  padding: 0.8rem;
+  border: 1px solid #dce9e5;
+  border-radius: 0.9rem;
+  color: #4e6d66;
+  background: #f9fcfb;
+}
+
+.demo-width-control > span {
+  display: flex;
+  justify-content: space-between;
+  color: #718b85;
+  font-size: 0.67rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.demo-width-control output {
+  color: #186f59;
+}
+
+.demo-width-control input {
+  width: 100%;
+  min-height: 1.7rem;
+  margin-top: 0.25rem;
+  accent-color: #18a47e;
+  cursor: pointer;
+}
+
+.demo-behavior-toggle,
+.demo-reset-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  cursor: pointer;
+  font-size: 0.72rem;
+  text-align: left;
+}
+
+.demo-behavior-toggle:hover,
+.demo-reset-button:hover {
+  border-color: #98cabb;
+  background: #effaf6;
+}
+
+.demo-behavior-toggle strong {
+  color: #168665;
+}
+
+.demo-reset-button {
+  min-width: 4.75rem;
+  justify-content: center;
+  color: #295e54;
+  font-weight: 780;
+}
+
+.demo-command-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 0.75rem;
+  padding: 0.85rem;
+  border: 1px dashed #c8ded7;
+  border-radius: 0.9rem;
+  background: #f6fbf9;
+}
+
+.demo-command-bar small,
+.demo-command-bar strong {
+  display: block;
+}
+
+.demo-command-bar small {
+  color: #718b85;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.demo-command-bar strong {
+  margin-top: 0.25rem;
+  color: #315f56;
+  font-size: 0.76rem;
+}
+
+.demo-command-bar code {
+  color: #147657;
+  font-size: 0.72rem;
+}
+
+.demo-command-bar > div:last-child {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.demo-command-bar button {
+  min-height: 2.75rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid #cfe1db;
+  border-radius: 0.65rem;
+  color: #315f56;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 750;
+}
+
+.demo-command-bar button:hover {
+  border-color: #72bda7;
+  color: #0d5a49;
 }
 
 .demo-control-group {
@@ -539,6 +867,18 @@ a:focus-visible {
   font-size: 0.72rem;
 }
 
+.demo-footer nav {
+  display: flex;
+  gap: 0.9rem;
+}
+
+.demo-footer a {
+  color: #416b62;
+  font-weight: 700;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2rem;
+}
+
 @keyframes demo-spin {
   to {
     transform: rotate(1turn);
@@ -556,8 +896,18 @@ a:focus-visible {
   }
 
   .demo-toolbar,
+  .demo-behaviors,
   .demo-feature-grid {
     grid-template-columns: 1fr;
+  }
+
+  .demo-snippet-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .demo-command-bar {
+    align-items: start;
+    flex-direction: column;
   }
 
   .demo-event-card {
@@ -590,7 +940,19 @@ a:focus-visible {
   }
 
   .demo-hero__visual {
-    width: min(14rem, 62vw);
+    display: none;
+  }
+
+  .demo-snippet-tabs {
+    grid-template-columns: 1fr;
+  }
+
+  .demo-snippet__header {
+    align-items: start;
+  }
+
+  .demo-snippet__header p {
+    display: none;
   }
 
   .demo-section-heading,
@@ -602,10 +964,22 @@ a:focus-visible {
   .demo-event-card dl {
     grid-template-columns: 0.8fr 0.6fr 1.6fr;
   }
+
+  .demo-footer nav {
+    flex-wrap: wrap;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .demo-orbit {
     animation: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .demo-state-dot.is-active,
+  .demo-snippet-tabs button span,
+  .demo-button--primary {
+    border: 1px solid ButtonText;
   }
 }

--- a/libs/ngx-multi-level-push-menu/README.md
+++ b/libs/ngx-multi-level-push-menu/README.md
@@ -4,9 +4,12 @@
 
 [![npm version](https://badge.fury.io/js/@ramiz4%2Fngx-multi-level-push-menu.svg)](https://www.npmjs.com/package/@ramiz4/ngx-multi-level-push-menu)
 [![CI](https://github.com/ramiz4/ngx-multi-level-push-menu/actions/workflows/ci.yml/badge.svg)](https://github.com/ramiz4/ngx-multi-level-push-menu/actions/workflows/ci.yml)
+[![Live demo](https://img.shields.io/badge/live_demo-open-18a47e)](https://ramiz4.github.io/ngx-multi-level-push-menu/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://github.com/ramiz4/ngx-multi-level-push-menu/blob/main/LICENSE)
 
 Accessible, responsive, SSR-safe multi-level push navigation for Angular. The library is standalone-first, has no icon or animation dependency, and still supports existing NgModule applications.
+
+[Open the interactive demo](https://ramiz4.github.io/ngx-multi-level-push-menu/) to try every public input, targeted service commands, typed output events, RTL, theming, and copy-ready setup examples.
 
 ## Why use it?
 
@@ -166,6 +169,7 @@ The visible-label fallback order is `name`, `title`, `id`, then `Untitled item`.
 ### Routing behavior
 
 - Same-context internal links use the optional Angular `Router` when one is available.
+- Rendered internal anchor URLs include the application's base href, so open-in-new-tab and modified clicks also work from subpath deployments.
 - External, protocol-relative, fragment, modified-click, and non-`_self` links keep native anchor behavior.
 - `target="_blank"` is protected with `rel="noopener noreferrer"` unless `rel` is supplied.
 - Set `closeOnNavigation` to collapse after native navigation starts or Angular Router navigation succeeds.

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.html
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.html
@@ -151,7 +151,7 @@
               data-menu-control
               data-menu-item-control
               [attr.data-menu-item-index]="itemIndex"
-              [href]="item.link || ''"
+              [href]="itemHref(item)"
               [attr.target]="item.target || null"
               [attr.rel]="safeRel(item)"
               [attr.aria-label]="itemAriaLabel(item)"

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.spec.ts
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.spec.ts
@@ -278,6 +278,26 @@ describe('MultiLevelPushMenuComponent', () => {
     expect(control?.hasAttribute('href')).toBe(false);
   });
 
+  it('prepares internal anchor hrefs with the application base path', () => {
+    const componentWithLocation = component as unknown as {
+      location: { prepareExternalUrl: (url: string) => string };
+    };
+    componentWithLocation.location = {
+      prepareExternalUrl: (url) => `/repository${url}`,
+    };
+    component.menu = [
+      { name: 'Internal', link: '/products' },
+      { name: 'External', link: 'https://example.com/products' },
+      { name: 'Fragment', link: '#details' },
+    ];
+    fixture.detectChanges();
+
+    const links = Array.from(element.querySelectorAll('a'));
+    expect(links[0]?.getAttribute('href')).toBe('/repository/products');
+    expect(links[1]?.getAttribute('href')).toBe('https://example.com/products');
+    expect(links[2]?.getAttribute('href')).toBe('#details');
+  });
+
   it('resets the level once when a controlled collapse does not preserve it', () => {
     const levelChange = jest.spyOn(component.levelChange, 'emit');
     clickControl('Alpha');

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.ts
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.ts
@@ -1,4 +1,9 @@
-import { CommonModule, DOCUMENT, isPlatformBrowser } from '@angular/common';
+import {
+  CommonModule,
+  DOCUMENT,
+  isPlatformBrowser,
+  Location,
+} from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -44,6 +49,7 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly menuService = inject(MultiLevelPushMenuService);
   private readonly router = inject(Router, { optional: true });
+  private readonly location = inject(Location, { optional: true });
   private readonly document = inject(DOCUMENT);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private _options = new MultiLevelPushMenuOptions();
@@ -338,6 +344,14 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
       .catch(() => {
         // Navigation errors remain owned by the application's Router error handler.
       });
+  }
+
+  /** @internal */
+  protected itemHref(item: MultiLevelPushMenuItem): string {
+    const link = item.link?.trim() || '';
+    if (!link || !this.location || this.isNativeOnlyLink(link)) return link;
+
+    return this.location.prepareExternalUrl(link);
   }
 
   goBack(focusParent = true): void {
@@ -699,7 +713,11 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
     }
 
     const link = item.link?.trim() || '';
-    return !/^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(link);
+    return !this.isNativeOnlyLink(link);
+  }
+
+  private isNativeOnlyLink(link: string): boolean {
+    return /^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(link);
   }
 
   private itemKey(item: MultiLevelPushMenuItem, index: number): string {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start": "nx serve",
     "build": "nx run-many --target=build --all",
     "build:app": "nx build multi-level-push-menu-example",
+    "prepare:pages": "node tools/scripts/prepare-pages.mjs",
     "build:lib": "nx build ngx-multi-level-push-menu",
     "build:libs": "nx run-many --target=build --projects=tag:lib",
     "build:apps": "nx run-many --target=build --projects=tag:app",

--- a/tools/scripts/prepare-pages.mjs
+++ b/tools/scripts/prepare-pages.mjs
@@ -1,0 +1,65 @@
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
+import { extname, resolve } from 'node:path';
+
+const workspaceRoot = resolve(import.meta.dirname, '../..');
+const outputRoot = resolve(
+  workspaceRoot,
+  'dist/apps/multi-level-push-menu-example',
+);
+const indexPath = resolve(outputRoot, 'index.html');
+const fallbackPath = resolve(outputRoot, '404.html');
+const baseHref = process.env.BASE_HREF;
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+
+const collectFiles = (directory) =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name);
+    return entry.isDirectory() ? collectFiles(path) : [path];
+  });
+
+assert(
+  typeof baseHref === 'string' &&
+    baseHref.startsWith('/') &&
+    baseHref.endsWith('/') &&
+    !baseHref.includes('..'),
+  'BASE_HREF must be an absolute, trailing-slash path such as /repository/.',
+);
+assert(
+  existsSync(indexPath),
+  `Missing Pages entry point at ${indexPath}. Build the demo first.`,
+);
+
+const index = readFileSync(indexPath, 'utf8');
+const renderedBaseHref = index.match(/<base\s+href=["']([^"']+)["']/i)?.[1];
+assert(
+  renderedBaseHref === baseHref,
+  `Expected the built index to use <base href="${baseHref}">, received "${renderedBaseHref ?? 'none'}".`,
+);
+
+const sourceMaps = collectFiles(outputRoot).filter(
+  (file) => extname(file) === '.map',
+);
+assert(
+  sourceMaps.length === 0,
+  `Production Pages output must not contain source maps: ${sourceMaps.join(', ')}`,
+);
+
+copyFileSync(indexPath, fallbackPath);
+writeFileSync(resolve(outputRoot, '.nojekyll'), '');
+
+assert(
+  existsSync(fallbackPath),
+  'Failed to create the Angular Router fallback.',
+);
+console.log(
+  `Prepared GitHub Pages artifact at ${outputRoot} with base href ${baseHref} and 404.html fallback.`,
+);

--- a/tools/scripts/validate-automation.mjs
+++ b/tools/scripts/validate-automation.mjs
@@ -48,6 +48,7 @@ const releaseWorkflow = readFileSync(
   resolve(workflowRoot, 'release.yml'),
   'utf8',
 );
+const pagesWorkflow = readFileSync(resolve(workflowRoot, 'pages.yml'), 'utf8');
 assert(
   /\bid-token:\s*write\b/.test(releaseWorkflow),
   'The release job must grant id-token: write for npm OIDC.',
@@ -63,6 +64,49 @@ assert(
 assert(
   !/\bGH_TOKEN:/.test(releaseWorkflow),
   'Do not pass github.token as GH_TOKEN: Semantic Release requires the x-access-token prefix selected by GITHUB_TOKEN.',
+);
+
+for (const [workflowName, workflow] of [
+  ['Release', releaseWorkflow],
+  ['Demo', pagesWorkflow],
+]) {
+  for (const guard of [
+    "github.event.workflow_run.conclusion == 'success'",
+    "github.event.workflow_run.event == 'push'",
+    'github.event.workflow_run.head_branch == github.event.repository.default_branch',
+    'github.event.workflow_run.head_repository.full_name == github.repository',
+  ]) {
+    assert(
+      workflow.includes(guard),
+      `${workflowName} must guard its privileged workflow_run job with ${guard}.`,
+    );
+  }
+  assert(
+    workflow.includes('ref: ${{ github.event.workflow_run.head_sha }}'),
+    `${workflowName} must check out the exact commit validated by CI.`,
+  );
+}
+
+assert(
+  /\bpages:\s*write\b/.test(pagesWorkflow) &&
+    /\bid-token:\s*write\b/.test(pagesWorkflow),
+  'The Pages deploy job must grant only the deployment permissions it needs.',
+);
+assert(
+  /\bpackage-manager-cache:\s*false\b/.test(pagesWorkflow) &&
+    !/^\s*cache:\s*npm\s*$/m.test(pagesWorkflow),
+  'Pages builds must not consume a shared package-manager cache.',
+);
+assert(
+  pagesWorkflow.includes('BASE_HREF: ${{ steps.pages.outputs.base_path }}/') &&
+    pagesWorkflow.includes('npm run prepare:pages'),
+  'Pages must use the configured site base path and validate its static artifact.',
+);
+assert(
+  /environment:\s*\n\s*name:\s*github-pages\s*\n\s*url:\s*\$\{\{\s*steps\.deployment\.outputs\.page_url\s*\}\}/.test(
+    pagesWorkflow,
+  ),
+  'Pages deployments must report their URL through the github-pages environment.',
 );
 
 assert(


### PR DESCRIPTION
## Summary

- turns the example app into a copy-first interactive product demo with live inputs, targeted service commands, typed outputs, accessible snippets, responsive behavior, and project links
- deploys the exact successfully validated `main` commit to GitHub Pages through a separate least-privilege `workflow_run` pipeline
- derives Angular's base href from GitHub Pages, validates the production artifact, and provides a `404.html` Router fallback
- fixes internal menu anchor hrefs so modified clicks and “open in new tab” respect the application's base path
- adds unit, E2E, automation-policy, and Pages-artifact coverage

## Verification

- `npm run format`
- `npm run lint`
- `npm run validate:automation`
- `npm run test:app -- --watch=false --runInBand` (11 tests)
- `npm run test:lib -- --watch=false --runInBand` (35 tests)
- `npm run build:lib`
- Pages production build with `BASE_HREF=/ngx-multi-level-push-menu/`
- `npm run prepare:pages`
- `node tools/scripts/validate-package.mjs`

## One-time repository setting

Before the first deployment, set **Settings → Pages → Build and deployment → Source** to **GitHub Actions**. The GitHub App available here has push access but not the administration permission required to change that setting.

After merge, successful CI independently triggers both Semantic Release (a patch for the base-path fix) and the Demo deployment.