### PR TITLE
fix: keep overlap mode distinct on mobile

### DIFF
--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -171,4 +171,20 @@ describe('multi-level push menu playground', () => {
       );
     });
   });
+
+  it('keeps overlap visually distinct from cover on mobile', () => {
+    cy.getByTestId('mode-overlap').click();
+    cy.viewport(375, 812);
+
+    getActiveMenuControl('Open Products menu').click();
+    getMenu()
+      .find('.ngx-push-menu__level[data-level-index="0"]')
+      .should('have.css', 'transform', 'matrix(1, 0, 0, 1, 0, 0)');
+    getActiveLevel().should(
+      'have.css',
+      'transform',
+      'matrix(1, 0, 0, 1, 52, 0)',
+    );
+    getActiveMenuControl('Open Analytics menu').should('be.visible');
+  });
 });

--- a/apps/multi-level-push-menu-example/src/app/app.component.html
+++ b/apps/multi-level-push-menu-example/src/app/app.component.html
@@ -227,6 +227,13 @@
                 Overlap
               </button>
             </div>
+            <small class="demo-control-help">
+              {{
+                options.mode === 'cover'
+                  ? 'Each level fully replaces its parent.'
+                  : 'Parent levels remain visible as navigation rails.'
+              }}
+            </small>
           </fieldset>
 
           <div class="demo-control-group">

--- a/apps/multi-level-push-menu-example/src/styles.scss
+++ b/apps/multi-level-push-menu-example/src/styles.scss
@@ -687,6 +687,14 @@ a:focus-visible {
   font-weight: 750;
 }
 
+.demo-control-help {
+  display: block;
+  margin-top: 0.55rem;
+  color: #718b85;
+  font-size: 0.65rem;
+  line-height: 1.4;
+}
+
 .demo-segmented button.is-selected {
   color: #0c5445;
   background: #fff;

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/models/multi-level-push-menu-options.model.ts
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/models/multi-level-push-menu-options.model.ts
@@ -9,7 +9,7 @@ export class MultiLevelPushMenuOptions {
   /** JS array of menu items (if markup not provided) */
   public menu: MultiLevelPushMenuItem[] = [];
 
-  /** Sliding layout. Overlap automatically uses cover-style motion below 48rem. */
+  /** Sliding layout. Cover replaces parent levels; overlap keeps them visible as rails. */
   public mode: 'cover' | 'overlap' = 'cover';
 
   /** Initialize menu in collapsed/expanded mode */

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.html
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.html
@@ -10,6 +10,7 @@
   [style.--ngx-push-menu-width]="menuWidth"
   [style.--ngx-push-menu-height]="menuHeight"
   [style.--ngx-push-menu-overlap]="overlapWidth"
+  [style.--ngx-push-menu-active-overlap-offset]="activeOverlapOffset"
   [style.--ngx-push-menu-duration]="animationDuration"
   [style.--ngx-push-menu-active-level]="activeLevelIndex"
 >
@@ -42,6 +43,7 @@
       class="ngx-push-menu__level"
       [style.--ngx-push-menu-level]="levelIndex"
       [style.--ngx-push-menu-cover-offset]="coverLevelOffset(levelIndex)"
+      [style.--ngx-push-menu-overlap-offset]="overlapLevelOffset(levelIndex)"
       [attr.data-level-index]="levelIndex"
       [attr.data-active]="isLevelActive(levelIndex)"
       [attr.data-entering]="enteringLevelKey() === level.key ? 'true' : null"

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
@@ -87,7 +87,6 @@
   overflow: hidden;
   background: var(--ngx-push-menu-background, #336ca6);
   transition: transform var(--ngx-push-menu-duration, 280ms) ease;
-  will-change: transform;
 }
 
 .ngx-push-menu--cover.ngx-push-menu--ltr .ngx-push-menu__level {
@@ -179,7 +178,6 @@
   overscroll-behavior: contain;
   list-style: none;
   scrollbar-gutter: stable;
-  -webkit-overflow-scrolling: touch;
 }
 
 .ngx-push-menu--collapsed .ngx-push-menu__back,

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
@@ -22,8 +22,8 @@
 
 .ngx-push-menu--overlap {
   --ngx-push-menu-effective-width: calc(
-    var(--ngx-push-menu-rendered-width) + var(--ngx-push-menu-active-level) *
-      var(--ngx-push-menu-overlap)
+    var(--ngx-push-menu-rendered-width) +
+      var(--ngx-push-menu-active-overlap-offset)
   );
 }
 
@@ -99,15 +99,11 @@
 }
 
 .ngx-push-menu--overlap.ngx-push-menu--ltr .ngx-push-menu__level {
-  transform: translateX(
-    calc(var(--ngx-push-menu-level) * var(--ngx-push-menu-overlap))
-  );
+  transform: translateX(var(--ngx-push-menu-overlap-offset));
 }
 
 .ngx-push-menu--overlap.ngx-push-menu--rtl .ngx-push-menu__level {
-  transform: translateX(
-    calc(var(--ngx-push-menu-level) * var(--ngx-push-menu-overlap) * -1)
-  );
+  transform: translateX(var(--ngx-push-menu-overlap-offset));
 }
 
 .ngx-push-menu__level[aria-hidden='true'] {
@@ -323,14 +319,6 @@
 
   .ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse) {
     --ngx-push-menu-content-offset: var(--ngx-push-menu-overlap);
-  }
-
-  .ngx-push-menu--overlap.ngx-push-menu--ltr .ngx-push-menu__level {
-    transform: translateX(var(--ngx-push-menu-cover-offset));
-  }
-
-  .ngx-push-menu--overlap.ngx-push-menu--rtl .ngx-push-menu__level {
-    transform: translateX(var(--ngx-push-menu-cover-offset));
   }
 }
 

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.spec.ts
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.spec.ts
@@ -150,6 +150,43 @@ describe('MultiLevelPushMenuComponent', () => {
     ).toBe('100%');
   });
 
+  it('renders distinct overlap offsets in both writing directions', () => {
+    fixture.componentRef.setInput(
+      'options',
+      new MultiLevelPushMenuOptions({
+        menu,
+        mode: 'overlap',
+        overlapWidth: '3rem',
+      }),
+    );
+    fixture.detectChanges();
+    clickControl('Alpha');
+
+    const activeLevel = element.querySelector<HTMLElement>(
+      '.ngx-push-menu__level[data-level-index="1"]',
+    );
+    expect(
+      activeLevel?.style.getPropertyValue('--ngx-push-menu-overlap-offset'),
+    ).toBe('calc(0px + 3rem)');
+
+    fixture.componentRef.setInput(
+      'options',
+      new MultiLevelPushMenuOptions({
+        menu,
+        mode: 'overlap',
+        overlapWidth: '3rem',
+        direction: 'rtl',
+      }),
+    );
+    fixture.detectChanges();
+    const rtlActiveLevel = element.querySelector<HTMLElement>(
+      '.ngx-push-menu__level[data-level-index="1"]',
+    );
+    expect(
+      rtlActiveLevel?.style.getPropertyValue('--ngx-push-menu-overlap-offset'),
+    ).toBe('calc(0px - 3rem)');
+  });
+
   it('removes old levels when menu data becomes empty', () => {
     clickControl('Alpha');
     expect(component.activeLevelIndex).toBe(1);

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.ts
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.ts
@@ -183,6 +183,11 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   }
 
   /** @internal */
+  protected get activeOverlapOffset(): string {
+    return this.repeatedCssLength(this.overlapWidth, this.activeLevelIndex);
+  }
+
+  /** @internal */
   protected get overlapWidthPixels(): number {
     const value =
       typeof this._options.overlapWidth === 'number'
@@ -267,6 +272,15 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   protected coverLevelOffset(index: number): string {
     const direction = this._options.direction === 'rtl' ? -1 : 1;
     return `${(index - this.activeLevelIndex) * direction * 100}%`;
+  }
+
+  /** @internal */
+  protected overlapLevelOffset(index: number): string {
+    return this.repeatedCssLength(
+      this.overlapWidth,
+      index,
+      this._options.direction === 'rtl',
+    );
   }
 
   /** @internal */
@@ -749,6 +763,21 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
       return Number.isFinite(value) ? `${Math.max(value, 0)}px` : fallback;
     }
     return value?.trim() || fallback;
+  }
+
+  private repeatedCssLength(
+    value: string,
+    count: number,
+    negative = false,
+  ): string {
+    const repetitions = Math.max(Math.trunc(count), 0);
+    if (repetitions === 0) return '0px';
+
+    const operator = negative ? ' - ' : ' + ';
+    return `calc(0px${operator}${Array.from(
+      { length: repetitions },
+      () => value,
+    ).join(operator)})`;
   }
 
   private normalizedMaxDepth(): number {


### PR DESCRIPTION
## Summary

- removes the responsive rule that silently converted `overlap` into `cover` below 48rem
- keeps parent menu levels visible as 52px rails on mobile, making the two public modes visually and behaviorally distinct
- replaces remaining CSS multiplication with concrete, direction-aware overlap offsets for stronger Safari compatibility
- removes persistent `will-change` and legacy `-webkit-overflow-scrolling: touch` from transformed submenu layers; this avoids the iOS WebKit paint stall where content appears only after another tap
- explains the active mode directly in the demo controls
- adds LTR/RTL unit coverage and a 375px E2E assertion for the visible parent rail

## Expected behavior

- **Cover:** each submenu fully replaces its parent level
- **Overlap:** parent levels remain visible as rails; nested levels are offset by `overlapWidth`
- submenu headers and items paint during the transition without a second tap

## Verification

- 37 library unit/SSR tests
- full workspace lint
- production library and demo build
- mobile Cypress scenarios included in CI

The public Pages domain remains blocked by the execution environment's browser safety policy. Final iOS Safari verification therefore uses the reporter's real device after deployment.