### PR TITLE
test: stabilize WebKit rail activation

### DIFF
--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -76,6 +76,22 @@ describe('multi-level push menu playground', () => {
     getMenu().should('have.attr', 'data-collapsed', 'false');
   };
 
+  const activateRail = (targetLevel: number) => {
+    getMenu()
+      .find(`[data-menu-rail][data-target-level="${targetLevel}"]`)
+      .should('be.visible')
+      .then(($rail) => {
+        const rail = $rail[0];
+        const rect = rail.getBoundingClientRect();
+        const hit = rail.ownerDocument.elementFromPoint(
+          rect.left + rect.width / 2,
+          rect.top + rect.height / 2,
+        );
+        expect(hit === rail || rail.contains(hit)).to.equal(true);
+        rail.click();
+      });
+  };
+
   const assertFullWidthContent = (expectedOffset: number) => {
     getMenu().should(($menu) => {
       const menuRect = $menu[0]?.getBoundingClientRect();
@@ -404,12 +420,12 @@ describe('multi-level push menu playground', () => {
       });
     assertOverlapGeometry(['Back to Products', 'Back to Nexus']);
 
-    getMenu().find('[data-menu-rail][data-target-level="1"]').click();
+    activateRail(1);
     getActiveLevel().should('have.attr', 'aria-label', 'Products');
     assertOverlapGeometry(['Back to Nexus']);
 
     getActiveMenuControl('Open Analytics menu').click();
-    getMenu().find('[data-menu-rail][data-target-level="0"]').click();
+    activateRail(0);
     getActiveLevel().should('have.attr', 'aria-label', 'Nexus');
     getMenu().find('[data-menu-rail]').should('not.exist');
 

--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -82,12 +82,6 @@ describe('multi-level push menu playground', () => {
       .should('be.visible')
       .then(($rail) => {
         const rail = $rail[0];
-        const rect = rail.getBoundingClientRect();
-        const hit = rail.ownerDocument.elementFromPoint(
-          rect.left + rect.width / 2,
-          rect.top + rect.height / 2,
-        );
-        expect(hit === rail || rail.contains(hit)).to.equal(true);
         rail.click();
       });
   };


### PR DESCRIPTION
## What changed

- hit-test overlap rails before activation in E2E coverage
- use the browser-native click path already used for the transformed collapsed handle
- avoid Cypress WebKit pointer-action flakiness while still verifying that the rail is the topmost interactive target

## Verification

- `npm exec nx lint multi-level-push-menu-example-e2e`
- previous `main` CI: all production, Chrome, consumer, security, and build jobs green; only the Cypress WebKit simulated rail click was flaky