### PR TITLE
fix: make menu transitions smooth and continuous

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ While expanded, the area outside the visible drawer acts as a close target and d
 | `closeOnNavigation`             | `boolean`                                                             | `true`               | Collapse after leaf navigation                                                                            |
 | `preserveActiveLevelOnCollapse` | `boolean`                                                             | `true`               | Keep the submenu stack across collapse/expand                                                             |
 | `maxDepth`                      | `number`                                                              | `50`                 | Maximum submenu depth; also limits malformed/cyclic data                                                  |
-| `animationDuration`             | `string \| number`                                                    | `280`                | CSS time or milliseconds when numeric                                                                     |
+| `animationDuration`             | `string \| number`                                                    | `500`                | CSS time or milliseconds when numeric                                                                     |
 
 ## Icons
 

--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -356,6 +356,36 @@ describe('multi-level push menu playground', () => {
     closeFromOutside();
   });
 
+  it('keeps entering and exiting panels mounted for the complete motion', () => {
+    cy.viewport(375, 812);
+
+    getActiveMenuControl('Open Products menu').click();
+    getActiveLevel()
+      .should('have.attr', 'aria-label', 'Products')
+      .and('have.attr', 'data-entering', 'true')
+      .then(($level) => {
+        const style = getComputedStyle($level[0]);
+        expect(style.animationName).to.contain('ngx-push-menu-enter');
+        expect(style.animationDuration).to.equal('0.5s');
+      });
+    getActiveLevel().should('not.have.attr', 'data-entering');
+
+    getBackButton().click();
+    getActiveLevel().should('have.attr', 'aria-label', 'Nexus');
+    getMenu()
+      .find('.ngx-push-menu__level[data-exiting="true"]')
+      .should('have.attr', 'aria-label', 'Products')
+      .and('have.attr', 'aria-hidden', 'true')
+      .then(($level) => {
+        const style = getComputedStyle($level[0]);
+        expect(style.animationName).to.contain('ngx-push-menu-exit');
+        expect(style.animationDuration).to.equal('0.5s');
+      });
+    getMenu()
+      .find('.ngx-push-menu__level[data-exiting="true"]')
+      .should('not.exist');
+  });
+
   it('stacks clickable overlap rails and paints deep mobile levels immediately', () => {
     cy.viewport(375, 812);
 

--- a/apps/multi-level-push-menu-example/src/app/app.component.ts
+++ b/apps/multi-level-push-menu-example/src/app/app.component.ts
@@ -362,7 +362,7 @@ export class AppComponent {
       backText: 'Back',
       closeOnNavigation: true,
       preserveActiveLevelOnCollapse: true,
-      animationDuration: 240,
+      animationDuration: 500,
     });
   }
 

--- a/libs/ngx-multi-level-push-menu/README.md
+++ b/libs/ngx-multi-level-push-menu/README.md
@@ -278,7 +278,7 @@ While expanded, the area outside the visible drawer acts as a close target and d
 | `closeOnNavigation`             | `boolean`                                                             | `true`               | Collapse after leaf navigation                                                                            |
 | `preserveActiveLevelOnCollapse` | `boolean`                                                             | `true`               | Keep the submenu stack across collapse/expand                                                             |
 | `maxDepth`                      | `number`                                                              | `50`                 | Maximum submenu depth; also limits malformed/cyclic data                                                  |
-| `animationDuration`             | `string \| number`                                                    | `280`                | CSS time or milliseconds when numeric                                                                     |
+| `animationDuration`             | `string \| number`                                                    | `500`                | CSS time or milliseconds when numeric                                                                     |
 
 ## Icons
 

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/models/multi-level-push-menu-options.model.ts
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/models/multi-level-push-menu-options.model.ts
@@ -80,7 +80,7 @@ export class MultiLevelPushMenuOptions {
   public maxDepth = 50;
 
   /** Animation duration as milliseconds or a valid CSS time. */
-  public animationDuration: string | number = 280;
+  public animationDuration: string | number = 500;
 
   constructor(options?: Partial<MultiLevelPushMenuOptions>) {
     if (options) {

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.html
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.html
@@ -8,6 +8,7 @@
   [class.ngx-push-menu--ltr]="options.direction === 'ltr'"
   [class.ngx-push-menu--rtl]="options.direction === 'rtl'"
   [class.ngx-push-menu--entering]="enteringLevelKey() !== null"
+  [class.ngx-push-menu--exiting]="exitingLevelKey() !== null"
   [style.--ngx-push-menu-width]="menuWidth"
   [style.--ngx-push-menu-height]="menuHeight"
   [style.--ngx-push-menu-overlap]="overlapWidth"
@@ -46,10 +47,11 @@
       [attr.data-level-index]="levelIndex"
       [attr.data-active]="isLevelActive(levelIndex)"
       [attr.data-entering]="enteringLevelKey() === level.key ? 'true' : null"
+      [attr.data-exiting]="exitingLevelKey() === level.key ? 'true' : null"
       [attr.aria-hidden]="isLevelAccessible(levelIndex) ? null : 'true'"
       [attr.inert]="isLevelAccessible(levelIndex) ? null : ''"
       [attr.aria-label]="level.title"
-      (animationend)="finishLevelEntry(level.key, $event)"
+      (animationend)="finishLevelMotion(level.key, $event)"
     >
       <header class="ngx-push-menu__header">
         <ramiz4-menu-icon
@@ -225,8 +227,8 @@
         [attr.aria-label]="railLabel(rail)"
         [attr.title]="railLabel(rail)"
         [attr.tabindex]="railTabIndex(rail.levelIndex)"
-        [attr.aria-hidden]="isCollapsed() ? 'true' : null"
-        [attr.inert]="isCollapsed() ? '' : null"
+        [attr.aria-hidden]="railIsAccessible() ? null : 'true'"
+        [attr.inert]="railIsAccessible() ? null : ''"
         (click)="activateRail(rail.levelIndex)"
       >
         <span class="ngx-push-menu__rail-header" aria-hidden="true">

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
@@ -6,6 +6,7 @@
 }
 
 .ngx-push-menu {
+  --ngx-push-menu-motion-easing: cubic-bezier(0.25, 0.1, 0.25, 1);
   --ngx-push-menu-rendered-width: var(--ngx-push-menu-width, 300px);
   --ngx-push-menu-effective-width: var(--ngx-push-menu-rendered-width);
   --ngx-push-menu-collapsed-handle-width: max(
@@ -41,9 +42,12 @@
   overflow: hidden;
   background: var(--ngx-push-menu-background, #336ca6);
   box-shadow: var(--ngx-push-menu-shadow, 0 0.5rem 1.5rem rgb(0 0 0 / 24%));
-  transition:
-    transform var(--ngx-push-menu-duration, 280ms) ease,
-    inline-size var(--ngx-push-menu-duration, 280ms) ease;
+  transform: translate3d(0, 0, 0);
+  transition: transform var(--ngx-push-menu-duration, 500ms)
+    var(--ngx-push-menu-motion-easing);
+  backface-visibility: hidden;
+  contain: layout paint style;
+  will-change: transform;
 }
 
 .ngx-push-menu--rtl .ngx-push-menu__navigation {
@@ -51,22 +55,24 @@
   left: auto;
 }
 
+.ngx-push-menu--ltr {
+  --ngx-push-menu-motion-edge: -100%;
+}
+
+.ngx-push-menu--rtl {
+  --ngx-push-menu-motion-edge: 100%;
+}
+
 .ngx-push-menu--ltr.ngx-push-menu--collapsed .ngx-push-menu__navigation {
-  transform: translateX(calc(0px - var(--ngx-push-menu-effective-width)));
+  transform: translate3d(
+    calc(0px - var(--ngx-push-menu-effective-width)),
+    0,
+    0
+  );
 }
 
 .ngx-push-menu--rtl.ngx-push-menu--collapsed .ngx-push-menu__navigation {
-  transform: translateX(var(--ngx-push-menu-effective-width));
-}
-
-.ngx-push-menu--ltr.ngx-push-menu--collapsed.ngx-push-menu--full-collapse
-  .ngx-push-menu__navigation {
-  transform: translateX(calc(0px - var(--ngx-push-menu-effective-width)));
-}
-
-.ngx-push-menu--rtl.ngx-push-menu--collapsed.ngx-push-menu--full-collapse
-  .ngx-push-menu__navigation {
-  transform: translateX(var(--ngx-push-menu-effective-width));
+  transform: translate3d(var(--ngx-push-menu-effective-width), 0, 0);
 }
 
 .ngx-push-menu__level {
@@ -81,24 +87,24 @@
   min-block-size: 0;
   overflow: hidden;
   background: var(--ngx-push-menu-background, #336ca6);
-  transition: transform var(--ngx-push-menu-duration, 280ms) ease;
+  transform: translate3d(0, 0, 0);
+  backface-visibility: hidden;
+  will-change: transform;
 }
 
-.ngx-push-menu--cover.ngx-push-menu--ltr .ngx-push-menu__level {
-  transform: translateX(var(--ngx-push-menu-cover-offset));
+.ngx-push-menu--cover .ngx-push-menu__level {
+  transform: translate3d(var(--ngx-push-menu-cover-offset), 0, 0);
 }
 
-.ngx-push-menu--cover.ngx-push-menu--rtl .ngx-push-menu__level {
-  transform: translateX(var(--ngx-push-menu-cover-offset));
-}
-
-.ngx-push-menu--overlap:not(.ngx-push-menu--entering)
-  .ngx-push-menu__level[data-active='false'] {
+.ngx-push-menu--overlap
+  .ngx-push-menu__level[data-active='false']:not([data-entering='true']):not(
+    [data-exiting='true']
+  ) {
   visibility: hidden;
 }
 
 .ngx-push-menu--overlap .ngx-push-menu__level[data-active='true'] {
-  transform: none;
+  transform: translate3d(0, 0, 0);
 }
 
 .ngx-push-menu__level[aria-hidden='true'] {
@@ -133,6 +139,9 @@
   border-inline-start: 1px solid
     var(--ngx-push-menu-border, rgb(255 255 255 / 18%));
   cursor: pointer;
+  backface-visibility: hidden;
+  animation: ngx-push-menu-rail-enter var(--ngx-push-menu-duration, 500ms)
+    var(--ngx-push-menu-motion-easing) both;
 }
 
 .ngx-push-menu__rail:hover,
@@ -346,19 +355,22 @@
   min-inline-size: 0;
   overflow: auto;
   color: initial;
-  transform: translateX(0);
-  transition: transform var(--ngx-push-menu-duration, 280ms) ease;
+  transform: translate3d(0, 0, 0);
+  transition: transform var(--ngx-push-menu-duration, 500ms)
+    var(--ngx-push-menu-motion-easing);
+  backface-visibility: hidden;
+  will-change: transform;
   -webkit-overflow-scrolling: touch;
 }
 
 .ngx-push-menu--cover.ngx-push-menu--ltr:not(.ngx-push-menu--collapsed)
   .ngx-push-menu__content {
-  transform: translateX(var(--ngx-push-menu-rendered-width));
+  transform: translate3d(var(--ngx-push-menu-rendered-width), 0, 0);
 }
 
 .ngx-push-menu--cover.ngx-push-menu--rtl:not(.ngx-push-menu--collapsed)
   .ngx-push-menu__content {
-  transform: translateX(calc(0px - var(--ngx-push-menu-rendered-width)));
+  transform: translate3d(calc(0px - var(--ngx-push-menu-rendered-width)), 0, 0);
 }
 
 .ngx-push-menu__backdrop {
@@ -409,33 +421,45 @@
   }
 }
 
-.ngx-push-menu--ltr .ngx-push-menu__level[data-entering='true'] {
-  animation: ngx-push-menu-enter-ltr var(--ngx-push-menu-duration, 280ms)
-    cubic-bezier(0.22, 1, 0.36, 1) both;
+.ngx-push-menu__level[data-entering='true'] {
+  animation: ngx-push-menu-enter var(--ngx-push-menu-duration, 500ms)
+    var(--ngx-push-menu-motion-easing) both;
 }
 
-.ngx-push-menu--rtl .ngx-push-menu__level[data-entering='true'] {
-  animation: ngx-push-menu-enter-rtl var(--ngx-push-menu-duration, 280ms)
-    cubic-bezier(0.22, 1, 0.36, 1) both;
+.ngx-push-menu__level[data-exiting='true'] {
+  animation: ngx-push-menu-exit var(--ngx-push-menu-duration, 500ms)
+    var(--ngx-push-menu-motion-easing) both;
 }
 
-@keyframes ngx-push-menu-enter-ltr {
+@keyframes ngx-push-menu-enter {
   from {
-    transform: translateX(100%);
+    transform: translate3d(var(--ngx-push-menu-motion-edge), 0, 0);
   }
 
   to {
-    transform: translateX(0);
+    transform: translate3d(0, 0, 0);
   }
 }
 
-@keyframes ngx-push-menu-enter-rtl {
+@keyframes ngx-push-menu-exit {
   from {
-    transform: translateX(-100%);
+    transform: translate3d(0, 0, 0);
   }
 
   to {
-    transform: translateX(0);
+    transform: translate3d(var(--ngx-push-menu-motion-edge), 0, 0);
+  }
+}
+
+@keyframes ngx-push-menu-rail-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(var(--ngx-push-menu-motion-edge), 0, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
   }
 }
 
@@ -448,6 +472,11 @@
   }
 
   .ngx-push-menu__level[data-entering='true'] {
+    animation-duration: 1ms;
+  }
+
+  .ngx-push-menu__level[data-exiting='true'],
+  .ngx-push-menu__rail {
     animation-duration: 1ms;
   }
 }

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.spec.ts
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.spec.ts
@@ -141,7 +141,7 @@ describe('MultiLevelPushMenuComponent', () => {
     expect(activeLevelText()).not.toContain('Beta child');
   });
 
-  it('renders cover offsets directly instead of relying on CSS arithmetic', () => {
+  it('keeps covered ancestors stationary while descendants exit toward the drawer edge', () => {
     clickControl('Alpha');
 
     const rootLevel = element.querySelector<HTMLElement>(
@@ -152,7 +152,7 @@ describe('MultiLevelPushMenuComponent', () => {
     );
     expect(
       rootLevel?.style.getPropertyValue('--ngx-push-menu-cover-offset'),
-    ).toBe('-100%');
+    ).toBe('0%');
     expect(
       activeLevel?.style.getPropertyValue('--ngx-push-menu-cover-offset'),
     ).toBe('0%');
@@ -164,7 +164,7 @@ describe('MultiLevelPushMenuComponent', () => {
     fixture.detectChanges();
     expect(
       rootLevel?.style.getPropertyValue('--ngx-push-menu-cover-offset'),
-    ).toBe('100%');
+    ).toBe('0%');
   });
 
   it('renders accessible overlap rails from the parent outward', () => {
@@ -236,7 +236,17 @@ describe('MultiLevelPushMenuComponent', () => {
     rails[1]?.click();
     fixture.detectChanges();
     expect(activeLevelTitle()).toBe('Nexus');
+    const exitingLevel = element.querySelector<HTMLElement>(
+      '.ngx-push-menu__level[data-exiting="true"]',
+    );
+    expect(exitingLevel?.getAttribute('aria-label')).toBe('Analytics');
+    expect(exitingLevel?.getAttribute('aria-hidden')).toBe('true');
+    expect(element.querySelectorAll('[data-menu-rail]')).toHaveLength(2);
+
+    exitingLevel?.dispatchEvent(new Event('animationend', { bubbles: true }));
+    fixture.detectChanges();
     expect(element.querySelectorAll('[data-menu-rail]')).toHaveLength(0);
+    expect(element.querySelector('[data-exiting="true"]')).toBeNull();
     expect(levelChangeSpy).toHaveBeenLastCalledWith(0);
   });
 

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.ts
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.ts
@@ -65,12 +65,17 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   private hasExplicitCollapsedInput = false;
   private hasReceivedOptions = false;
   private focusFrame: number | null = null;
+  private levelExitTimer: number | null = null;
   private readonly serviceSubscription: Subscription;
   private readonly levelsState = signal<readonly MenuLevel[]>([]);
+  private readonly activeLevelIndexState = signal(0);
   private readonly collapsedState = signal(false);
   private readonly swipingState = signal(false);
   private readonly announcementState = signal('');
   private readonly enteringLevelKeyState = signal<string | null>(null);
+  private readonly exitingLevelKeyState = signal<string | null>(null);
+  private exitTargetDepth: number | null = null;
+  private exitFocusSelector: string | null = null;
 
   /** @internal Read-only template state; writable signals stay private. */
   protected readonly levels: Signal<readonly MenuLevel[]> =
@@ -83,6 +88,8 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   protected readonly announcement = this.announcementState.asReadonly();
   /** @internal Decorative entry state; visibility never depends on cleanup. */
   protected readonly enteringLevelKey = this.enteringLevelKeyState.asReadonly();
+  /** @internal Decorative exit state; the panel stays mounted until motion ends. */
+  protected readonly exitingLevelKey = this.exitingLevelKeyState.asReadonly();
 
   @Input()
   set menu(menuItems: readonly MultiLevelPushMenuItem[] | null | undefined) {
@@ -101,6 +108,7 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
       | null
       | undefined,
   ) {
+    this.completePendingLevelExit();
     const shouldRestoreFocus = this.focusIsInsideNavigation();
     const previousDepth = this.activeLevelIndex;
     const previousRootItems = this.rootItems();
@@ -160,10 +168,14 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   ngOnDestroy(): void {
     this.serviceSubscription.unsubscribe();
     this.cancelPendingFocus();
+    this.cancelLevelExitTimer();
   }
 
   get activeLevelIndex(): number {
-    return Math.max(this.levels().length - 1, 0);
+    return Math.max(
+      0,
+      Math.min(this.activeLevelIndexState(), this.levels().length - 1),
+    );
   }
 
   /** @internal */
@@ -188,13 +200,13 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
 
   /** @internal */
   protected get activeOverlapOffset(): string {
-    return this.repeatedCssLength(this.overlapWidth, this.activeLevelIndex);
+    return this.repeatedCssLength(this.overlapWidth, this.renderedLevelIndex);
   }
 
   /** @internal Ancestors ordered from the active panel out toward content. */
   protected get ancestorRails(): readonly MenuRail[] {
     return this.levels()
-      .slice(0, -1)
+      .slice(0, this.renderedLevelIndex)
       .map((level, levelIndex) => ({
         key: level.key,
         levelIndex,
@@ -217,7 +229,7 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   protected get animationDuration(): string {
     const value = this._options.animationDuration;
     if (typeof value === 'number') return `${Math.max(value, 0)}ms`;
-    return value?.trim() || '280ms';
+    return value?.trim() || '500ms';
   }
 
   /** @internal */
@@ -302,7 +314,12 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   /** @internal */
   protected railTabIndex(levelIndex: number): number {
     void levelIndex;
-    return this.isCollapsed() ? -1 : 0;
+    return this.isCollapsed() || this.exitingLevelKey() !== null ? -1 : 0;
+  }
+
+  /** @internal */
+  protected railIsAccessible(): boolean {
+    return !this.isCollapsed() && this.exitingLevelKey() === null;
   }
 
   /** @internal */
@@ -317,8 +334,8 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
 
   /** @internal */
   protected coverLevelOffset(index: number): string {
-    const direction = this._options.direction === 'rtl' ? -1 : 1;
-    return `${(index - this.activeLevelIndex) * direction * 100}%`;
+    if (index <= this.activeLevelIndex) return '0%';
+    return this._options.direction === 'rtl' ? '100%' : '-100%';
   }
 
   /** @internal */
@@ -328,6 +345,8 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
     originalEvent: MouseEvent | KeyboardEvent,
   ): void {
     if (item.disabled || !this.hasChildren(item)) return;
+
+    this.completePendingLevelExit();
 
     originalEvent.preventDefault();
     if (this._options.preventGroupItemClick) {
@@ -359,7 +378,11 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
     };
 
     this.enteringLevelKeyState.set(nextLevel.key);
-    this.levelsState.update((levels) => [...levels, nextLevel]);
+    this.levelsState.update((levels) => {
+      const nextLevels = [...levels, nextLevel];
+      this.activeLevelIndexState.set(nextLevels.length - 1);
+      return nextLevels;
+    });
     this.emitGroupActivation(item, originalEvent, path);
     this.emitLevelChanged();
     this.announce(`Opened ${nextLevel.title}.`);
@@ -367,10 +390,13 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   }
 
   /** @internal */
-  protected finishLevelEntry(key: string, event: AnimationEvent): void {
+  protected finishLevelMotion(key: string, event: AnimationEvent): void {
     if (event.target !== event.currentTarget) return;
     if (this.enteringLevelKeyState() === key) {
       this.enteringLevelKeyState.set(null);
+    }
+    if (this.exitingLevelKeyState() === key) {
+      this.completeLevelExit(key);
     }
   }
 
@@ -433,6 +459,7 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
 
   /** @internal */
   protected activateRail(levelIndex: number): void {
+    if (levelIndex >= this.activeLevelIndex) return;
     this.returnToDepth(levelIndex, true);
   }
 
@@ -602,9 +629,14 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   }
 
   private resetLevels(emit = true): void {
+    this.cancelLevelExitTimer();
     this.enteringLevelKeyState.set(null);
+    this.exitingLevelKeyState.set(null);
+    this.exitTargetDepth = null;
+    this.exitFocusSelector = null;
     const previousDepth = this.activeLevelIndex;
     this.levelsState.set([this.createRootLevel()]);
+    this.activeLevelIndexState.set(0);
     if (emit && previousDepth !== 0) this.levelChange.emit(0);
   }
 
@@ -626,6 +658,9 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
     if (!rootChanged && trimmedLevels.length === currentLevels.length) return;
 
     this.levelsState.set([root, ...trimmedLevels.slice(1)]);
+    this.activeLevelIndexState.set(
+      Math.min(previousDepth, trimmedLevels.length - 1),
+    );
     if (this.activeLevelIndex !== previousDepth) this.emitLevelChanged();
   }
 
@@ -647,6 +682,7 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   }
 
   private returnToDepth(level: number, focusParent: boolean): void {
+    this.completePendingLevelExit();
     this.enteringLevelKeyState.set(null);
     const currentLevels = this.levels();
     if (currentLevels.length <= 1 || !Number.isFinite(level)) return;
@@ -657,23 +693,33 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
     );
     const shouldRestoreFocus = focusParent && this.focusIsInsideNavigation();
     const firstRemovedLevel = currentLevels[safeLevel + 1];
+    const exitingLevel = currentLevels[this.activeLevelIndex];
 
-    this.levelsState.set(currentLevels.slice(0, safeLevel + 1));
+    this.activeLevelIndexState.set(safeLevel);
+    this.exitTargetDepth = safeLevel;
+    this.exitingLevelKeyState.set(exitingLevel?.key ?? null);
     this.emitLevelChanged();
     this.announce(`Returned to ${this.activeLevel?.title || 'Menu'}.`);
 
-    if (
-      shouldRestoreFocus &&
-      firstRemovedLevel?.parentItemIndex !== undefined
-    ) {
-      this.scheduleFocus(
-        `[data-menu-item-index="${firstRemovedLevel.parentItemIndex}"]`,
-      );
+    this.exitFocusSelector =
+      shouldRestoreFocus && firstRemovedLevel?.parentItemIndex !== undefined
+        ? `[data-menu-item-index="${firstRemovedLevel.parentItemIndex}"]`
+        : null;
+
+    if (!exitingLevel || !this.isBrowser) {
+      this.completeLevelExit(exitingLevel?.key ?? '');
+      return;
     }
+
+    this.scheduleLevelExitFallback(exitingLevel.key);
   }
 
   private rebuildStackFromPath(path: readonly MultiLevelPushMenuItem[]): void {
+    this.cancelLevelExitTimer();
     this.enteringLevelKeyState.set(null);
+    this.exitingLevelKeyState.set(null);
+    this.exitTargetDepth = null;
+    this.exitFocusSelector = null;
     const stack: MenuLevel[] = [this.createRootLevel()];
     let items = this.rootItems();
     let parentPath: MultiLevelPushMenuItem[] = [];
@@ -694,6 +740,7 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
     }
 
     this.levelsState.set(stack);
+    this.activeLevelIndexState.set(stack.length - 1);
   }
 
   private findItemPath(
@@ -744,7 +791,10 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
 
   private transitionCollapsed(value: boolean, emit = true): void {
     const shouldRestoreFocus = value && this.focusIsInsideNavigation();
-    if (value) this.enteringLevelKeyState.set(null);
+    if (value) {
+      this.enteringLevelKeyState.set(null);
+      this.completePendingLevelExit();
+    }
 
     if (value && !this._options.preserveActiveLevelOnCollapse) {
       this.resetLevels();
@@ -845,6 +895,65 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
       { length: repetitions },
       () => value,
     ).join(operator)})`;
+  }
+
+  private get renderedLevelIndex(): number {
+    return this.exitingLevelKey() === null
+      ? this.activeLevelIndex
+      : Math.max(this.levels().length - 1, this.activeLevelIndex);
+  }
+
+  private completePendingLevelExit(): void {
+    const key = this.exitingLevelKeyState();
+    if (key !== null) this.completeLevelExit(key);
+  }
+
+  private completeLevelExit(key: string): void {
+    if (this.exitingLevelKeyState() !== key) return;
+
+    const targetDepth = this.exitTargetDepth ?? this.activeLevelIndex;
+    this.cancelLevelExitTimer();
+    this.levelsState.update((levels) => levels.slice(0, targetDepth + 1));
+    this.activeLevelIndexState.set(targetDepth);
+    this.exitingLevelKeyState.set(null);
+    this.exitTargetDepth = null;
+    const focusSelector = this.exitFocusSelector;
+    this.exitFocusSelector = null;
+    if (focusSelector) this.scheduleFocus(focusSelector);
+  }
+
+  private scheduleLevelExitFallback(key: string): void {
+    this.cancelLevelExitTimer();
+    const window = this.document.defaultView;
+    if (!window) {
+      this.completeLevelExit(key);
+      return;
+    }
+
+    this.levelExitTimer = window.setTimeout(
+      () => this.completeLevelExit(key),
+      this.animationDurationMilliseconds() + 80,
+    );
+  }
+
+  private animationDurationMilliseconds(): number {
+    const value = this._options.animationDuration;
+    if (typeof value === 'number') return Math.max(value, 0);
+
+    const normalized = value?.trim().toLowerCase() || '500ms';
+    const match = normalized.match(/^([\d.]+)(ms|s)$/);
+    if (!match) return 500;
+    const amount = Number.parseFloat(match[1]);
+    if (!Number.isFinite(amount)) return 500;
+    return Math.max(amount * (match[2] === 's' ? 1000 : 1), 0);
+  }
+
+  private cancelLevelExitTimer(): void {
+    const window = this.document.defaultView;
+    if (this.levelExitTimer !== null && window) {
+      window.clearTimeout(this.levelExitTimer);
+    }
+    this.levelExitTimer = null;
   }
 
   private normalizedMaxDepth(): number {


### PR DESCRIPTION
## What changed

- keep outgoing menu levels mounted until their exit animation completes, eliminating blank and jumping frames
- align forward/back motion with the physical drawer edge in LTR and RTL
- use synchronized 500 ms `translate3d` transitions with the Codrops reference easing
- keep overlap width and ancestor rails stable during exit, then clean them up atomically
- defer restored focus until the visual transition finishes
- add unit and mobile E2E coverage for persistent entering/exiting panels
- update the documented animation default to 500 ms

## Validation

- `npm run validate`
- 40 library tests
- 13 demo tests
- production library and demo builds
- package entry-point validation

The existing GitHub Actions browser matrix validates the new transition lifecycle in Chrome and WebKit.