### PR TITLE
docs(demo): add useful navigation destination pages

### DIFF
--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -213,6 +213,29 @@ describe('multi-level push menu playground', () => {
     getMenu().should('have.attr', 'data-collapsed', 'true');
   });
 
+  it('routes documentation items to useful about, guide and release pages', () => {
+    getActiveMenuControl('About the library').click();
+    cy.location('pathname').should('eq', '/about');
+    cy.getByTestId('route-about')
+      .should('be.visible')
+      .and('contain.text', 'Accessible by default');
+
+    expandFromHandle();
+    getActiveMenuControl('Open Resources menu').click();
+    getActiveMenuControl('Guides').click();
+    cy.location('pathname').should('eq', '/guides');
+    cy.getByTestId('route-guides')
+      .should('be.visible')
+      .and('contain.text', 'npm install');
+
+    expandFromHandle();
+    getActiveMenuControl('Release notes').click();
+    cy.location('pathname').should('eq', '/release-notes');
+    cy.getByTestId('route-release-notes')
+      .should('be.visible')
+      .and('contain.text', '20.0.6');
+  });
+
   it('keeps collapse and expand state controlled by the application', () => {
     getMenu().should('have.attr', 'data-collapsed', 'false');
 

--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -216,6 +216,7 @@ describe('multi-level push menu playground', () => {
   it('routes documentation items to useful about, guide and release pages', () => {
     getActiveMenuControl('About the library').click();
     cy.location('pathname').should('eq', '/about');
+    cy.getByTestId('route-about').scrollIntoView();
     cy.getByTestId('route-about')
       .should('be.visible')
       .and('contain.text', 'Accessible by default');
@@ -224,6 +225,7 @@ describe('multi-level push menu playground', () => {
     getActiveMenuControl('Open Resources menu').click();
     getActiveMenuControl('Guides').click();
     cy.location('pathname').should('eq', '/guides');
+    cy.getByTestId('route-guides').scrollIntoView();
     cy.getByTestId('route-guides')
       .should('be.visible')
       .and('contain.text', 'npm install');
@@ -231,6 +233,7 @@ describe('multi-level push menu playground', () => {
     expandFromHandle();
     getActiveMenuControl('Release notes').click();
     cy.location('pathname').should('eq', '/release-notes');
+    cy.getByTestId('route-release-notes').scrollIntoView();
     cy.getByTestId('route-release-notes')
       .should('be.visible')
       .and('contain.text', '20.0.6');

--- a/apps/multi-level-push-menu-example/src/app/about-us/about-us.component.html
+++ b/apps/multi-level-push-menu-example/src/app/about-us/about-us.component.html
@@ -1,13 +1,48 @@
 <article class="demo-route" data-testid="route-about">
-  <p class="demo-eyebrow">Built for real applications</p>
-  <h2>Navigation without framework friction.</h2>
+  <p class="demo-eyebrow">Why this library exists</p>
+  <h2>Deep navigation without framework friction.</h2>
   <p>
-    Nexus is the demo product; the menu is the real story. It keeps rendering,
-    state and keyboard behavior together while leaving routing and domain data
-    in your application.
+    ngx-multi-level-push-menu turns a typed menu tree into accessible,
+    responsive navigation. Your application keeps ownership of routing, state,
+    content and design tokens; the library handles the difficult interaction
+    details.
   </p>
-  <div class="demo-code">
-    &lt;ngx-multi-level-push-menu [menu]="menuItems" [options]="options"
-    [(collapsed)]="collapsed" (itemActivate)="onActivate($event)" /&gt;
+
+  <div class="demo-feature-grid">
+    <section class="demo-feature">
+      <span>01</span>
+      <h3>Accessible by default</h3>
+      <p>Keyboard navigation, focus restoration and meaningful ARIA state.</p>
+    </section>
+    <section class="demo-feature">
+      <span>02</span>
+      <h3>Angular-native</h3>
+      <p>
+        Standalone-first, typed outputs, SSR-safe and compatible with NgModule.
+      </p>
+    </section>
+    <section class="demo-feature">
+      <span>03</span>
+      <h3>Design-system ready</h3>
+      <p>
+        CSS custom properties, custom SVG icons and no visual dependency
+        lock-in.
+      </p>
+    </section>
   </div>
+
+  <nav class="demo-route-actions" aria-label="Library links">
+    <a
+      href="https://github.com/ramiz4/ngx-multi-level-push-menu"
+      target="_blank"
+      rel="noopener noreferrer"
+      >View the source</a
+    >
+    <a
+      href="https://www.npmjs.com/package/@ramiz4/ngx-multi-level-push-menu"
+      target="_blank"
+      rel="noopener noreferrer"
+      >Open on npm</a
+    >
+  </nav>
 </article>

--- a/apps/multi-level-push-menu-example/src/app/app.component.spec.ts
+++ b/apps/multi-level-push-menu-example/src/app/app.component.spec.ts
@@ -25,6 +25,21 @@ describe('AppComponent', () => {
     ).not.toBeNull();
   });
 
+  it('provides real routes for every documentation menu item', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const component = fixture.componentInstance;
+    const resources = component.menuItems.find(
+      (item) => item.id === 'resources',
+    );
+    const about = component.menuItems.find((item) => item.id === 'about');
+
+    expect(resources?.items?.map((item) => item.link)).toEqual([
+      '/guides',
+      '/release-notes',
+    ]);
+    expect(about?.link).toBe('/about');
+  });
+
   it('updates display options immutably from the playground controls', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const component = fixture.componentInstance;

--- a/apps/multi-level-push-menu-example/src/app/app.component.ts
+++ b/apps/multi-level-push-menu-example/src/app/app.component.ts
@@ -172,7 +172,7 @@ export class AppComponent {
           id: 'guides',
           name: 'Guides',
           icon: ICONS.guide,
-          link: '/credits',
+          link: '/guides',
           data: {
             kind: 'route',
             description: 'Navigate to implementation guides',
@@ -182,9 +182,10 @@ export class AppComponent {
           id: 'release-notes',
           name: 'Release notes',
           icon: ICONS.spark,
+          link: '/release-notes',
           data: {
-            kind: 'action',
-            description: 'Handle an action without a router link',
+            kind: 'route',
+            description: 'See the latest library improvements',
           },
         },
       ],
@@ -193,7 +194,7 @@ export class AppComponent {
       id: 'about',
       name: 'About the library',
       icon: ICONS.about,
-      link: '/about-us',
+      link: '/about',
       data: {
         kind: 'route',
         description: 'Learn why this component is different',

--- a/apps/multi-level-push-menu-example/src/app/app.routes.ts
+++ b/apps/multi-level-push-menu-example/src/app/app.routes.ts
@@ -2,14 +2,18 @@ import { Routes } from '@angular/router';
 import { HomeComponent } from './home/home.component';
 import { AboutUsComponent } from './about-us/about-us.component';
 import { CollectionsComponent } from './collections/collections.component';
-import { CreditsComponent } from './credits/credits.component';
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
+import { GuidesComponent } from './guides/guides.component';
+import { ReleaseNotesComponent } from './release-notes/release-notes.component';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'home', component: HomeComponent },
-  { path: 'about-us', component: AboutUsComponent },
+  { path: 'about', component: AboutUsComponent },
+  { path: 'about-us', redirectTo: 'about', pathMatch: 'full' },
   { path: 'collections', component: CollectionsComponent },
-  { path: 'credits', component: CreditsComponent },
+  { path: 'guides', component: GuidesComponent },
+  { path: 'release-notes', component: ReleaseNotesComponent },
+  { path: 'credits', redirectTo: 'guides', pathMatch: 'full' },
   { path: '**', component: PageNotFoundComponent },
 ];

--- a/apps/multi-level-push-menu-example/src/app/guides/guides.component.html
+++ b/apps/multi-level-push-menu-example/src/app/guides/guides.component.html
@@ -1,0 +1,68 @@
+<article class="demo-route" data-testid="route-guides">
+  <p class="demo-eyebrow">Integration guide</p>
+  <h2>From install to production in four steps.</h2>
+  <p>
+    The public API stays intentionally small. Import the standalone component,
+    describe a typed menu tree, bind controlled state and adapt the design with
+    CSS custom properties.
+  </p>
+
+  <ol class="demo-guide-steps">
+    <li>
+      <span>1</span>
+      <div>
+        <h3>Install</h3>
+        <p><code>npm install @ramiz4/ngx-multi-level-push-menu</code></p>
+      </div>
+    </li>
+    <li>
+      <span>2</span>
+      <div>
+        <h3>Import</h3>
+        <p>
+          Add <code>MultiLevelPushMenuComponent</code> to the component imports.
+        </p>
+      </div>
+    </li>
+    <li>
+      <span>3</span>
+      <div>
+        <h3>Bind</h3>
+        <p>
+          Pass <code>menu</code>, <code>options</code> and optionally two-way
+          bind <code>collapsed</code>.
+        </p>
+      </div>
+    </li>
+    <li>
+      <span>4</span>
+      <div>
+        <h3>Observe</h3>
+        <p>
+          Use typed activation outputs for analytics, authorization and
+          application state.
+        </p>
+      </div>
+    </li>
+  </ol>
+
+  <div class="demo-code">
+    &lt;ngx-multi-level-push-menu [menu]="menuItems" [options]="options"
+    [(collapsed)]="collapsed" (itemActivate)="onActivate($event)" /&gt;
+  </div>
+
+  <nav class="demo-route-actions" aria-label="Guide links">
+    <a
+      href="https://github.com/ramiz4/ngx-multi-level-push-menu#quick-start"
+      target="_blank"
+      rel="noopener noreferrer"
+      >Read the full quick start</a
+    >
+    <a
+      href="https://github.com/ramiz4/ngx-multi-level-push-menu#configuration-reference"
+      target="_blank"
+      rel="noopener noreferrer"
+      >Configuration reference</a
+    >
+  </nav>
+</article>

--- a/apps/multi-level-push-menu-example/src/app/guides/guides.component.spec.ts
+++ b/apps/multi-level-push-menu-example/src/app/guides/guides.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { GuidesComponent } from './guides.component';
+
+describe('GuidesComponent', () => {
+  let fixture: ComponentFixture<GuidesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GuidesComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(GuidesComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders an actionable integration guide', () => {
+    const element = fixture.nativeElement as HTMLElement;
+    expect(
+      element.querySelector('[data-testid="route-guides"]'),
+    ).not.toBeNull();
+    expect(element.textContent).toContain('npm install');
+    expect(element.textContent).toContain('MultiLevelPushMenuComponent');
+  });
+});

--- a/apps/multi-level-push-menu-example/src/app/guides/guides.component.ts
+++ b/apps/multi-level-push-menu-example/src/app/guides/guides.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'ramiz4-guides',
+  templateUrl: './guides.component.html',
+})
+export class GuidesComponent {}

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.html
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.html
@@ -1,0 +1,51 @@
+<article class="demo-route" data-testid="route-release-notes">
+  <p class="demo-eyebrow">Release notes</p>
+  <h2>What changed, and why it matters.</h2>
+  <p>
+    Every release is produced from a validated main commit with semantic-release
+    and npm trusted publishing. Here are the improvements demonstrated by this
+    live build.
+  </p>
+
+  <div class="demo-release-list">
+    <section>
+      <div><strong>20.0.6</strong><span>Latest</span></div>
+      <h3>Smoother, continuous navigation</h3>
+      <p>
+        Persistent entering and exiting panels, synchronized 500 ms
+        GPU-composited transitions and stable Chrome/WebKit coverage.
+      </p>
+    </section>
+    <section>
+      <div><strong>20.0.5</strong></div>
+      <h3>Reliable mobile rendering</h3>
+      <p>
+        Immediate submenu painting, distinct cover and overlap modes,
+        outside-click close and full-width content behavior.
+      </p>
+    </section>
+    <section>
+      <div><strong>20.0.0</strong></div>
+      <h3>Modern Angular foundation</h3>
+      <p>
+        Standalone-first API, strict typed models, SSR safety and verified
+        Angular 20–22 consumers.
+      </p>
+    </section>
+  </div>
+
+  <nav class="demo-route-actions" aria-label="Release links">
+    <a
+      href="https://github.com/ramiz4/ngx-multi-level-push-menu/releases"
+      target="_blank"
+      rel="noopener noreferrer"
+      >All GitHub releases</a
+    >
+    <a
+      href="https://www.npmjs.com/package/@ramiz4/ngx-multi-level-push-menu?activeTab=versions"
+      target="_blank"
+      rel="noopener noreferrer"
+      >All npm versions</a
+    >
+  </nav>
+</article>

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReleaseNotesComponent } from './release-notes.component';
+
+describe('ReleaseNotesComponent', () => {
+  let fixture: ComponentFixture<ReleaseNotesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReleaseNotesComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ReleaseNotesComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders the current release and its improvements', () => {
+    const element = fixture.nativeElement as HTMLElement;
+    expect(
+      element.querySelector('[data-testid="route-release-notes"]'),
+    ).not.toBeNull();
+    expect(element.textContent).toContain('20.0.6');
+    expect(element.textContent).toContain('Smoother, continuous navigation');
+  });
+});

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.ts
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'ramiz4-release-notes',
+  templateUrl: './release-notes.component.html',
+})
+export class ReleaseNotesComponent {}

--- a/apps/multi-level-push-menu-example/src/styles.scss
+++ b/apps/multi-level-push-menu-example/src/styles.scss
@@ -866,6 +866,121 @@ a:focus-visible {
   white-space: pre;
 }
 
+.demo-route-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1.5rem;
+}
+
+.demo-route-actions a {
+  display: inline-flex;
+  min-height: 2.8rem;
+  align-items: center;
+  padding: 0.7rem 1rem;
+  border: 1px solid #cfe2dc;
+  border-radius: 0.75rem;
+  color: #0d5546;
+  background: #fff;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.demo-route-actions a:hover {
+  border-color: #62b99f;
+  box-shadow: 0 0.5rem 1.25rem rgb(15 96 75 / 9%);
+}
+
+.demo-guide-steps {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.demo-guide-steps li {
+  display: flex;
+  min-width: 0;
+  gap: 0.8rem;
+  padding: 1rem;
+  border: 1px solid #dfebe7;
+  border-radius: 1rem;
+  background: #f9fcfb;
+}
+
+.demo-guide-steps li > span {
+  display: grid;
+  flex: 0 0 2rem;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border-radius: 50%;
+  color: #effff9;
+  background: #168665;
+  font-size: 0.72rem;
+  font-weight: 850;
+}
+
+.demo-guide-steps h3,
+.demo-release-list h3 {
+  margin: 0;
+  color: #214a43;
+  font-size: 0.95rem;
+}
+
+.demo-guide-steps p,
+.demo-release-list p {
+  margin: 0.35rem 0 0;
+  color: #66817b;
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.demo-guide-steps code {
+  overflow-wrap: anywhere;
+  color: #12624f;
+  font-size: 0.74rem;
+}
+
+.demo-release-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.demo-release-list section {
+  padding: 1rem;
+  border: 1px solid #dfebe7;
+  border-radius: 1rem;
+  background: #f9fcfb;
+}
+
+.demo-release-list section > div {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.65rem;
+}
+
+.demo-release-list strong {
+  color: #168665;
+  font-size: 0.78rem;
+}
+
+.demo-release-list span {
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  color: #0d5546;
+  background: #daf4ea;
+  font-size: 0.6rem;
+  font-weight: 850;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
 .demo-footer {
   display: flex;
   justify-content: space-between;
@@ -905,7 +1020,8 @@ a:focus-visible {
 
   .demo-toolbar,
   .demo-behaviors,
-  .demo-feature-grid {
+  .demo-feature-grid,
+  .demo-guide-steps {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## What changed

- route **About the library** to a dedicated `/about` page with library principles and source/package links
- route **Resources → Guides** to `/guides` with an actionable four-step integration guide and copyable component example
- route **Resources → Release notes** to `/release-notes` with versioned improvement summaries and release links
- keep `/about-us` and `/credits` working as compatibility redirects
- add responsive styles, component tests, route configuration coverage, and a complete E2E navigation flow

## Validation

- `npm run validate`
- 40 library tests
- 16 demo tests
- production library and demo builds
- package entry-point validation

The PR CI additionally runs the route flow in Chrome and WebKit.