### PR TITLE
fix(demo): render overview through the router outlet

### DIFF
--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -201,15 +201,7 @@ describe('multi-level push menu playground', () => {
     cy.location('pathname').should('eq', '/collections');
     cy.getByTestId('route-collections').scrollIntoView();
     cy.getByTestId('route-collections').should('be.visible');
-    cy.getByTestId('event-kind').should('have.text', 'item');
-    cy.getByTestId('event-label').should(
-      'contain.text',
-      'Navigate to the live dashboard example',
-    );
-    cy.getByTestId('event-path').should(
-      'have.text',
-      'Products / Analytics / Live dashboard',
-    );
+    cy.get('#demo-heading').should('not.exist');
     getMenu().should('have.attr', 'data-collapsed', 'true');
   });
 
@@ -220,6 +212,7 @@ describe('multi-level push menu playground', () => {
     cy.getByTestId('route-about')
       .should('be.visible')
       .and('contain.text', 'Accessible by default');
+    cy.get('#demo-heading').should('not.exist');
 
     expandFromHandle();
     getActiveMenuControl('Open Resources menu').click();
@@ -229,6 +222,7 @@ describe('multi-level push menu playground', () => {
     cy.getByTestId('route-guides')
       .should('be.visible')
       .and('contain.text', 'npm install');
+    cy.get('#demo-heading').should('not.exist');
 
     expandFromHandle();
     getActiveMenuControl('Release notes').click();
@@ -237,6 +231,15 @@ describe('multi-level push menu playground', () => {
     cy.getByTestId('route-release-notes')
       .should('be.visible')
       .and('contain.text', '20.0.6');
+    cy.get('#demo-heading').should('not.exist');
+
+    expandFromHandle();
+    getActiveMenuControl('Overview').click();
+    cy.location('pathname').should('eq', '/home');
+    cy.get('#demo-heading')
+      .should('be.visible')
+      .and('contain.text', 'Deep navigation');
+    cy.getByTestId('route-release-notes').should('not.exist');
   });
 
   it('keeps collapse and expand state controlled by the application', () => {

--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -234,6 +234,7 @@ describe('multi-level push menu playground', () => {
     cy.get('#demo-heading').should('not.exist');
 
     expandFromHandle();
+    getBackButton().click();
     getActiveMenuControl('Overview').click();
     cy.location('pathname').should('eq', '/home');
     cy.get('#demo-heading')

--- a/apps/multi-level-push-menu-example/src/app/app.component.html
+++ b/apps/multi-level-push-menu-example/src/app/app.component.html
@@ -67,305 +67,310 @@
     </header>
 
     <div class="demo-content">
-      <section class="demo-hero" aria-labelledby="demo-heading">
-        <div>
-          <p class="demo-eyebrow">Live Angular 20–22 playground</p>
-          <h1 id="demo-heading">
-            Deep navigation.<br />Shallow learning curve.
-          </h1>
-          <p class="demo-lead">
-            Accessible, typed multi-level navigation with a standalone-first
-            API, no required providers and no design-system lock-in.
-          </p>
+      <router-outlet></router-outlet>
 
-          <div class="demo-hero__actions">
-            <button
-              type="button"
-              class="demo-button demo-button--primary"
-              data-testid="copy-install"
-              (click)="copySnippet(installSnippet)"
-            >
-              {{
-                copiedSnippetId() === 'install'
-                  ? 'Install command copied'
-                  : 'Copy npm install'
-              }}
-            </button>
-            <a
-              class="demo-button demo-button--secondary"
-              [href]="repositoryUrl"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              View source <span aria-hidden="true">&#8599;</span>
-            </a>
-          </div>
-
-          <div class="demo-pills" aria-label="Library highlights">
-            <span>Standalone</span>
-            <span>Typed outputs</span>
-            <span>SSR-safe</span>
-            <span>RTL ready</span>
-            <span>Zero icon dependencies</span>
-          </div>
-        </div>
-
-        <div class="demo-hero__visual" aria-hidden="true">
-          <div class="demo-orbit demo-orbit--outer"></div>
-          <div class="demo-orbit demo-orbit--inner"></div>
-          <div class="demo-cube"><span>N</span></div>
-          <span class="demo-particle demo-particle--one"></span>
-          <span class="demo-particle demo-particle--two"></span>
-          <span class="demo-particle demo-particle--three"></span>
-        </div>
-      </section>
-
-      <section
-        id="quick-start"
-        class="demo-quick-start"
-        aria-labelledby="quick-start-heading"
-      >
-        <div class="demo-section-heading">
+      <ng-template #overviewContent>
+        <section class="demo-hero" aria-labelledby="demo-heading">
           <div>
-            <p class="demo-eyebrow">Copy, understand, ship</p>
-            <h2 id="quick-start-heading">Four steps to production</h2>
-          </div>
-          <p>
-            Every example below is complete, typed and ready to adapt in a
-            standalone Angular application.
-          </p>
-        </div>
+            <p class="demo-eyebrow">Live Angular 20–22 playground</p>
+            <h1 id="demo-heading">
+              Deep navigation.<br />Shallow learning curve.
+            </h1>
+            <p class="demo-lead">
+              Accessible, typed multi-level navigation with a standalone-first
+              API, no required providers and no design-system lock-in.
+            </p>
 
-        <div
-          class="demo-snippet-tabs"
-          role="tablist"
-          aria-label="Quick start code examples"
-        >
-          @for (snippet of snippets; track snippet.id) {
-            <button
-              type="button"
-              role="tab"
-              [id]="'snippet-tab-' + snippet.id"
-              [attr.aria-controls]="'snippet-panel-' + snippet.id"
-              [attr.aria-selected]="activeSnippetId() === snippet.id"
-              [attr.tabindex]="activeSnippetId() === snippet.id ? 0 : -1"
-              [class.is-selected]="activeSnippetId() === snippet.id"
-              [attr.data-testid]="'snippet-' + snippet.id"
-              (click)="selectSnippet(snippet.id)"
-            >
-              <span>{{ snippet.step }}</span>
-              {{ snippet.title }}
-            </button>
-          }
-        </div>
-
-        @let snippet = activeSnippet();
-        <article
-          class="demo-snippet"
-          role="tabpanel"
-          [id]="'snippet-panel-' + snippet.id"
-          [attr.aria-labelledby]="'snippet-tab-' + snippet.id"
-        >
-          <header class="demo-snippet__header">
-            <div>
-              <span>{{ snippet.fileName }}</span>
-              <p>{{ snippet.description }}</p>
+            <div class="demo-hero__actions">
+              <button
+                type="button"
+                class="demo-button demo-button--primary"
+                data-testid="copy-install"
+                (click)="copySnippet(installSnippet)"
+              >
+                {{
+                  copiedSnippetId() === 'install'
+                    ? 'Install command copied'
+                    : 'Copy npm install'
+                }}
+              </button>
+              <a
+                class="demo-button demo-button--secondary"
+                [href]="repositoryUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View source <span aria-hidden="true">&#8599;</span>
+              </a>
             </div>
-            <button
-              type="button"
-              class="demo-copy-button"
-              data-testid="copy-snippet"
-              [attr.aria-label]="'Copy ' + snippet.title + ' code'"
-              (click)="copySnippet(snippet)"
-            >
-              {{ copiedSnippetId() === snippet.id ? 'Copied' : 'Copy' }}
-            </button>
-          </header>
-          <pre tabindex="0"><code
+
+            <div class="demo-pills" aria-label="Library highlights">
+              <span>Standalone</span>
+              <span>Typed outputs</span>
+              <span>SSR-safe</span>
+              <span>RTL ready</span>
+              <span>Zero icon dependencies</span>
+            </div>
+          </div>
+
+          <div class="demo-hero__visual" aria-hidden="true">
+            <div class="demo-orbit demo-orbit--outer"></div>
+            <div class="demo-orbit demo-orbit--inner"></div>
+            <div class="demo-cube"><span>N</span></div>
+            <span class="demo-particle demo-particle--one"></span>
+            <span class="demo-particle demo-particle--two"></span>
+            <span class="demo-particle demo-particle--three"></span>
+          </div>
+        </section>
+
+        <section
+          id="quick-start"
+          class="demo-quick-start"
+          aria-labelledby="quick-start-heading"
+        >
+          <div class="demo-section-heading">
+            <div>
+              <p class="demo-eyebrow">Copy, understand, ship</p>
+              <h2 id="quick-start-heading">Four steps to production</h2>
+            </div>
+            <p>
+              Every example below is complete, typed and ready to adapt in a
+              standalone Angular application.
+            </p>
+          </div>
+
+          <div
+            class="demo-snippet-tabs"
+            role="tablist"
+            aria-label="Quick start code examples"
+          >
+            @for (snippet of snippets; track snippet.id) {
+              <button
+                type="button"
+                role="tab"
+                [id]="'snippet-tab-' + snippet.id"
+                [attr.aria-controls]="'snippet-panel-' + snippet.id"
+                [attr.aria-selected]="activeSnippetId() === snippet.id"
+                [attr.tabindex]="activeSnippetId() === snippet.id ? 0 : -1"
+                [class.is-selected]="activeSnippetId() === snippet.id"
+                [attr.data-testid]="'snippet-' + snippet.id"
+                (click)="selectSnippet(snippet.id)"
+              >
+                <span>{{ snippet.step }}</span>
+                {{ snippet.title }}
+              </button>
+            }
+          </div>
+
+          @let snippet = activeSnippet();
+          <article
+            class="demo-snippet"
+            role="tabpanel"
+            [id]="'snippet-panel-' + snippet.id"
+            [attr.aria-labelledby]="'snippet-tab-' + snippet.id"
+          >
+            <header class="demo-snippet__header">
+              <div>
+                <span>{{ snippet.fileName }}</span>
+                <p>{{ snippet.description }}</p>
+              </div>
+              <button
+                type="button"
+                class="demo-copy-button"
+                data-testid="copy-snippet"
+                [attr.aria-label]="'Copy ' + snippet.title + ' code'"
+                (click)="copySnippet(snippet)"
+              >
+                {{ copiedSnippetId() === snippet.id ? 'Copied' : 'Copy' }}
+              </button>
+            </header>
+            <pre tabindex="0"><code
             [attr.data-language]="snippet.language"
             [textContent]="snippet.code"
           ></code></pre>
-        </article>
+          </article>
 
-        <p class="demo-visually-hidden" role="status" aria-live="polite">
-          {{ copyStatus() }}
-        </p>
-      </section>
-
-      <section class="demo-playground" aria-labelledby="playground-heading">
-        <div class="demo-section-heading">
-          <div>
-            <p class="demo-eyebrow">Live public API</p>
-            <h2 id="playground-heading">Make it yours</h2>
-          </div>
-          <p>
-            Use the menu on this page while every control updates its public
-            inputs in real time.
+          <p class="demo-visually-hidden" role="status" aria-live="polite">
+            {{ copyStatus() }}
           </p>
-        </div>
+        </section>
 
-        <div class="demo-toolbar">
-          <fieldset class="demo-control-group">
-            <legend>Transition</legend>
-            <div class="demo-segmented">
+        <section class="demo-playground" aria-labelledby="playground-heading">
+          <div class="demo-section-heading">
+            <div>
+              <p class="demo-eyebrow">Live public API</p>
+              <h2 id="playground-heading">Make it yours</h2>
+            </div>
+            <p>
+              Use the menu on this page while every control updates its public
+              inputs in real time.
+            </p>
+          </div>
+
+          <div class="demo-toolbar">
+            <fieldset class="demo-control-group">
+              <legend>Transition</legend>
+              <div class="demo-segmented">
+                <button
+                  type="button"
+                  data-testid="mode-cover"
+                  [class.is-selected]="options.mode === 'cover'"
+                  [attr.aria-pressed]="options.mode === 'cover'"
+                  (click)="setMode('cover')"
+                >
+                  Cover
+                </button>
+                <button
+                  type="button"
+                  data-testid="mode-overlap"
+                  [class.is-selected]="options.mode === 'overlap'"
+                  [attr.aria-pressed]="options.mode === 'overlap'"
+                  (click)="setMode('overlap')"
+                >
+                  Overlap
+                </button>
+              </div>
+              <small class="demo-control-help">
+                {{
+                  options.mode === 'cover'
+                    ? 'The drawer moves the full-width page without shrinking it.'
+                    : 'The drawer and its clickable rails overlay stationary content.'
+                }}
+              </small>
+            </fieldset>
+
+            <div class="demo-control-group">
+              <span>Direction</span>
               <button
                 type="button"
-                data-testid="mode-cover"
-                [class.is-selected]="options.mode === 'cover'"
-                [attr.aria-pressed]="options.mode === 'cover'"
-                (click)="setMode('cover')"
+                class="demo-setting-button"
+                data-testid="toggle-direction"
+                (click)="toggleDirection()"
               >
-                Cover
+                {{ options.direction.toUpperCase() }}
+                <span aria-hidden="true">&#8646;</span>
+              </button>
+            </div>
+
+            <div class="demo-control-group">
+              <span>Theme</span>
+              <button
+                type="button"
+                class="demo-setting-button"
+                data-testid="toggle-theme"
+                (click)="toggleTheme()"
+              >
+                {{ theme === 'aurora' ? 'Aurora' : 'Midnight' }}
+                <span class="demo-theme-swatch" aria-hidden="true"></span>
+              </button>
+            </div>
+          </div>
+
+          <div class="demo-behaviors">
+            <label class="demo-width-control">
+              <span>
+                Menu width
+                <output>{{ options.menuWidth }}px</output>
+              </span>
+              <input
+                type="range"
+                min="280"
+                max="380"
+                step="20"
+                [value]="options.menuWidth"
+                (input)="setMenuWidth($event)"
+              />
+            </label>
+
+            <button
+              type="button"
+              class="demo-behavior-toggle"
+              data-testid="toggle-close-on-navigation"
+              [attr.aria-pressed]="options.closeOnNavigation"
+              (click)="toggleCloseOnNavigation()"
+            >
+              <span>Close after route</span>
+              <strong>{{ options.closeOnNavigation ? 'On' : 'Off' }}</strong>
+            </button>
+
+            <button
+              type="button"
+              class="demo-behavior-toggle"
+              data-testid="toggle-preserve-level"
+              [attr.aria-pressed]="options.preserveActiveLevelOnCollapse"
+              (click)="togglePreserveLevel()"
+            >
+              <span>Preserve active level</span>
+              <strong>
+                {{ options.preserveActiveLevelOnCollapse ? 'On' : 'Off' }}
+              </strong>
+            </button>
+
+            <button
+              type="button"
+              class="demo-reset-button"
+              data-testid="reset-playground"
+              (click)="resetPlayground()"
+            >
+              Reset
+            </button>
+          </div>
+
+          <div class="demo-command-bar">
+            <div>
+              <small>Targeted service commands</small>
+              <strong>Control <code>#nexus-demo-menu</code></strong>
+            </div>
+            <div
+              role="group"
+              aria-label="Multi-level push menu service commands"
+            >
+              <button type="button" (click)="runServiceCommand('open')">
+                Open
               </button>
               <button
                 type="button"
-                data-testid="mode-overlap"
-                [class.is-selected]="options.mode === 'overlap'"
-                [attr.aria-pressed]="options.mode === 'overlap'"
-                (click)="setMode('overlap')"
+                data-testid="service-analytics"
+                (click)="runServiceCommand('analytics')"
               >
-                Overlap
+                Go to Analytics
+              </button>
+              <button type="button" (click)="runServiceCommand('back')">
+                Back
+              </button>
+              <button type="button" (click)="runServiceCommand('close')">
+                Close
               </button>
             </div>
-            <small class="demo-control-help">
-              {{
-                options.mode === 'cover'
-                  ? 'The drawer moves the full-width page without shrinking it.'
-                  : 'The drawer and its clickable rails overlay stationary content.'
-              }}
-            </small>
-          </fieldset>
-
-          <div class="demo-control-group">
-            <span>Direction</span>
-            <button
-              type="button"
-              class="demo-setting-button"
-              data-testid="toggle-direction"
-              (click)="toggleDirection()"
-            >
-              {{ options.direction.toUpperCase() }}
-              <span aria-hidden="true">&#8646;</span>
-            </button>
           </div>
 
-          <div class="demo-control-group">
-            <span>Theme</span>
-            <button
-              type="button"
-              class="demo-setting-button"
-              data-testid="toggle-theme"
-              (click)="toggleTheme()"
-            >
-              {{ theme === 'aurora' ? 'Aurora' : 'Midnight' }}
-              <span class="demo-theme-swatch" aria-hidden="true"></span>
-            </button>
-          </div>
-        </div>
-
-        <div class="demo-behaviors">
-          <label class="demo-width-control">
-            <span>
-              Menu width
-              <output>{{ options.menuWidth }}px</output>
-            </span>
-            <input
-              type="range"
-              min="280"
-              max="380"
-              step="20"
-              [value]="options.menuWidth"
-              (input)="setMenuWidth($event)"
-            />
-          </label>
-
-          <button
-            type="button"
-            class="demo-behavior-toggle"
-            data-testid="toggle-close-on-navigation"
-            [attr.aria-pressed]="options.closeOnNavigation"
-            (click)="toggleCloseOnNavigation()"
-          >
-            <span>Close after route</span>
-            <strong>{{ options.closeOnNavigation ? 'On' : 'Off' }}</strong>
-          </button>
-
-          <button
-            type="button"
-            class="demo-behavior-toggle"
-            data-testid="toggle-preserve-level"
-            [attr.aria-pressed]="options.preserveActiveLevelOnCollapse"
-            (click)="togglePreserveLevel()"
-          >
-            <span>Preserve active level</span>
-            <strong>
-              {{ options.preserveActiveLevelOnCollapse ? 'On' : 'Off' }}
-            </strong>
-          </button>
-
-          <button
-            type="button"
-            class="demo-reset-button"
-            data-testid="reset-playground"
-            (click)="resetPlayground()"
-          >
-            Reset
-          </button>
-        </div>
-
-        <div class="demo-command-bar">
-          <div>
-            <small>Targeted service commands</small>
-            <strong>Control <code>#nexus-demo-menu</code></strong>
-          </div>
-          <div role="group" aria-label="Multi-level push menu service commands">
-            <button type="button" (click)="runServiceCommand('open')">
-              Open
-            </button>
-            <button
-              type="button"
-              data-testid="service-analytics"
-              (click)="runServiceCommand('analytics')"
-            >
-              Go to Analytics
-            </button>
-            <button type="button" (click)="runServiceCommand('back')">
-              Back
-            </button>
-            <button type="button" (click)="runServiceCommand('close')">
-              Close
-            </button>
-          </div>
-        </div>
-
-        <div class="demo-event-card" aria-live="polite">
-          <div>
-            <span class="demo-event-card__icon" aria-hidden="true"
-              >&#8599;</span
-            >
-            <span>
-              <small>Latest typed output</small>
-              <strong data-testid="event-label">{{ lastEvent.label }}</strong>
-            </span>
-          </div>
-          <dl>
+          <div class="demo-event-card" aria-live="polite">
             <div>
-              <dt>Event</dt>
-              <dd data-testid="event-kind">{{ lastEvent.kind }}</dd>
+              <span class="demo-event-card__icon" aria-hidden="true"
+                >&#8599;</span
+              >
+              <span>
+                <small>Latest typed output</small>
+                <strong data-testid="event-label">{{ lastEvent.label }}</strong>
+              </span>
             </div>
-            <div>
-              <dt>Level</dt>
-              <dd data-testid="event-depth">{{ activeLevel }}</dd>
-            </div>
-            <div>
-              <dt>Path</dt>
-              <dd data-testid="event-path">{{ lastEvent.path }}</dd>
-            </div>
-          </dl>
-        </div>
-      </section>
-
-      <router-outlet></router-outlet>
+            <dl>
+              <div>
+                <dt>Event</dt>
+                <dd data-testid="event-kind">{{ lastEvent.kind }}</dd>
+              </div>
+              <div>
+                <dt>Level</dt>
+                <dd data-testid="event-depth">{{ activeLevel }}</dd>
+              </div>
+              <div>
+                <dt>Path</dt>
+                <dd data-testid="event-path">{{ lastEvent.path }}</dd>
+              </div>
+            </dl>
+          </div>
+        </section>
+      </ng-template>
 
       <footer class="demo-footer">
         <span>Built for Angular teams who care about the details.</span>

--- a/apps/multi-level-push-menu-example/src/app/app.component.spec.ts
+++ b/apps/multi-level-push-menu-example/src/app/app.component.spec.ts
@@ -11,15 +11,13 @@ describe('AppComponent', () => {
     }).compileComponents();
   });
 
-  it('renders the provider-free standalone playground', () => {
+  it('renders the persistent menu shell and routed-content outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
 
     const element = fixture.nativeElement as HTMLElement;
-    expect(element.querySelector('h1')?.textContent).toContain(
-      'Deep navigation',
-    );
     expect(element.querySelector('[data-testid="demo-menu"]')).not.toBeNull();
+    expect(element.querySelector('router-outlet')).not.toBeNull();
     expect(
       element.querySelector('[aria-label="Open Products menu"]'),
     ).not.toBeNull();
@@ -106,24 +104,12 @@ describe('AppComponent', () => {
     fixture.detectChanges();
     expect(fixture.componentInstance.collapsed).toBe(true);
 
-    element
-      .querySelector<HTMLElement>('[data-testid="toggle-direction"]')
-      ?.click();
-    fixture.detectChanges();
-    const rtlHandle = element.querySelector<HTMLElement>(
+    const collapsedHandle = element.querySelector<HTMLElement>(
       '[data-menu-collapsed-toggle]',
     );
-    expect(rtlHandle?.style.right).toBe('0px');
+    expect(collapsedHandle).not.toBeNull();
 
-    element.querySelector<HTMLElement>('[data-testid="mode-overlap"]')?.click();
-    fixture.detectChanges();
-    const overlapHandle = element.querySelector<HTMLElement>(
-      '[data-menu-collapsed-toggle]',
-    );
-    expect(fixture.componentInstance.options.direction).toBe('rtl');
-    expect(overlapHandle?.style.right).toBe('0px');
-
-    overlapHandle?.click();
+    collapsedHandle?.click();
     fixture.detectChanges();
 
     expect(fixture.componentInstance.collapsed).toBe(false);
@@ -164,11 +150,9 @@ describe('AppComponent', () => {
     fixture.detectChanges();
 
     expect(component.activeSnippet().id).toBe('template');
-    expect(
-      (fixture.nativeElement as HTMLElement).querySelector(
-        '[role="tabpanel"] code',
-      )?.textContent,
-    ).toContain('<ngx-multi-level-push-menu');
+    expect(component.activeSnippet().code).toContain(
+      '<ngx-multi-level-push-menu',
+    );
   });
 
   it('resets all live configuration through one public-options update', () => {

--- a/apps/multi-level-push-menu-example/src/app/app.component.ts
+++ b/apps/multi-level-push-menu-example/src/app/app.component.ts
@@ -5,6 +5,8 @@ import {
   computed,
   inject,
   signal,
+  TemplateRef,
+  ViewChild,
 } from '@angular/core';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import {
@@ -15,6 +17,7 @@ import {
   MultiLevelPushMenuService,
 } from '@ramiz4/ngx-multi-level-push-menu';
 import { DEMO_SNIPPETS, DemoSnippet, DemoSnippetId } from './demo-snippets';
+import { OverviewContentService } from './overview-content.service';
 
 type DemoEventKind = 'ready' | 'group' | 'item' | 'state';
 type DemoTheme = 'aurora' | 'midnight';
@@ -59,6 +62,12 @@ const ICONS = {
 export class AppComponent {
   private readonly document = inject(DOCUMENT);
   private readonly menuService = inject(MultiLevelPushMenuService);
+  private readonly overviewContent = inject(OverviewContentService);
+
+  @ViewChild('overviewContent')
+  set overviewTemplate(template: TemplateRef<unknown> | undefined) {
+    if (template) this.overviewContent.register(template);
+  }
 
   readonly repositoryUrl =
     'https://github.com/ramiz4/ngx-multi-level-push-menu';

--- a/apps/multi-level-push-menu-example/src/app/home/home.component.html
+++ b/apps/multi-level-push-menu-example/src/app/home/home.component.html
@@ -1,26 +1,3 @@
-<article class="demo-route" data-testid="route-home">
-  <p class="demo-eyebrow">Why it feels effortless</p>
-  <h2>Production primitives, polished by default.</h2>
-  <p>
-    Open a nested product menu, navigate with the arrow keys, or change the
-    direction above. The same component works for a fresh standalone app and an
-    established NgModule codebase.
-  </p>
-  <div class="demo-feature-grid">
-    <section class="demo-feature">
-      <span>01</span>
-      <h3>One component import</h3>
-      <p>No global provider, animation module, stylesheet or icon font.</p>
-    </section>
-    <section class="demo-feature">
-      <span>02</span>
-      <h3>Accessible interaction</h3>
-      <p>Semantic controls, focus management and direction-aware keys.</p>
-    </section>
-    <section class="demo-feature">
-      <span>03</span>
-      <h3>Typed context</h3>
-      <p>Attach domain data and receive the complete activation path.</p>
-    </section>
-  </div>
-</article>
+@if (overview.template(); as template) {
+  <ng-container [ngTemplateOutlet]="template" />
+}

--- a/apps/multi-level-push-menu-example/src/app/home/home.component.ts
+++ b/apps/multi-level-push-menu-example/src/app/home/home.component.ts
@@ -1,7 +1,13 @@
-import { Component } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { OverviewContentService } from '../overview-content.service';
 
 @Component({
   selector: 'ramiz4-home',
+  imports: [NgTemplateOutlet],
   templateUrl: './home.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HomeComponent {}
+export class HomeComponent {
+  protected readonly overview = inject(OverviewContentService);
+}

--- a/apps/multi-level-push-menu-example/src/app/overview-content.service.ts
+++ b/apps/multi-level-push-menu-example/src/app/overview-content.service.ts
@@ -1,0 +1,10 @@
+import { Injectable, signal, TemplateRef } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class OverviewContentService {
+  readonly template = signal<TemplateRef<unknown> | null>(null);
+
+  register(template: TemplateRef<unknown>): void {
+    this.template.set(template);
+  }
+}


### PR DESCRIPTION
## Summary
- render the complete Angular playground exclusively from the Overview route
- keep only the shared navigation shell, topbar, footer, and router outlet persistent
- ensure About, Guides, Collections, and Release Notes replace the overview instead of appearing below it
- extend Chrome/WebKit coverage for exclusive routed content and returning to Overview

## Validation
- `npm run validate`