### PR TITLE
docs(demo): align release notes with 20.0.7

### DIFF
--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -230,7 +230,7 @@ describe('multi-level push menu playground', () => {
     cy.getByTestId('route-release-notes').scrollIntoView();
     cy.getByTestId('route-release-notes')
       .should('be.visible')
-      .and('contain.text', '20.0.6');
+      .and('contain.text', '20.0.7');
     cy.get('#demo-heading').should('not.exist');
 
     expandFromHandle();

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.html
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.html
@@ -9,7 +9,7 @@
 
   <div class="demo-release-list">
     <section>
-      <div><strong>20.0.6</strong><span>Latest</span></div>
+      <div><strong>20.0.7</strong><span>Latest</span></div>
       <h3>Smoother, continuous navigation</h3>
       <p>
         Persistent entering and exiting panels, synchronized 500 ms

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
@@ -17,7 +17,7 @@ describe('ReleaseNotesComponent', () => {
     expect(
       element.querySelector('[data-testid="route-release-notes"]'),
     ).not.toBeNull();
-    expect(element.textContent).toContain('20.0.6');
+    expect(element.textContent).toContain('20.0.7');
     expect(element.textContent).toContain('Smoother, continuous navigation');
   });
 });


### PR DESCRIPTION
Update the demo release notes and their unit/browser assertions after the routed-content fix was released as 20.0.7.