### PR TITLE
feat: keep a full-height icon rail when collapsed

### DIFF
--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -272,10 +272,15 @@ describe('multi-level push menu playground', () => {
 
     closeFromOutside();
     getMenu().should('have.attr', 'data-collapsed', 'true');
-    getActiveLevel().find('.ngx-push-menu__items').should('have.attr', 'inert');
+    getActiveLevel()
+      .find('.ngx-push-menu__items')
+      .should('not.have.attr', 'inert');
     getActiveLevel()
       .find('.ngx-push-menu__item-control')
-      .should('have.attr', 'tabindex', '-1');
+      .first()
+      .should('have.attr', 'tabindex', '0');
+    getActiveLevel().find('.ngx-push-menu__item-icon').should('be.visible');
+    getActiveLevel().find('.ngx-push-menu__item-label').should('not.be.visible');
     cy.getByTestId('menu-state').should('contain.text', 'Collapsed');
 
     cy.getByTestId('expand-menu').click();

--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -10,7 +10,7 @@ describe('multi-level push menu playground', () => {
     getMenu().should(($menu) => {
       const menuRect = $menu[0].getBoundingClientRect();
       const handle = $menu[0].querySelector<HTMLElement>(
-        '[data-menu-collapsed-toggle]',
+        '.ngx-push-menu__level[data-active="true"] [data-menu-toggle]',
       );
       expect(handle).not.to.equal(null);
       if (!handle) return;
@@ -61,7 +61,7 @@ describe('multi-level push menu playground', () => {
   const expandFromHandle = () => {
     assertCollapsedHandleSettled();
     getMenu()
-      .find('[data-menu-collapsed-toggle]')
+      .find('.ngx-push-menu__level[data-active="true"] [data-menu-toggle]')
       .should('be.visible')
       .then(($handle) => {
         const handle = $handle[0];
@@ -105,6 +105,30 @@ describe('multi-level push menu playground', () => {
       if (!menuRect || !contentRect) return;
       expect(contentRect.width).to.be.closeTo(menuRect.width, 1);
       expect(contentRect.left).to.be.closeTo(menuRect.left + expectedOffset, 1);
+    });
+  };
+
+  const assertCollapsedContent = (direction: 'ltr' | 'rtl' = 'ltr') => {
+    getMenu().should(($menu) => {
+      const menuRect = $menu[0].getBoundingClientRect();
+      const contentRect = $menu[0]
+        .querySelector<HTMLElement>('.ngx-push-menu__content')
+        ?.getBoundingClientRect();
+      const navigationRect = $menu[0]
+        .querySelector<HTMLElement>('.ngx-push-menu__navigation')
+        ?.getBoundingClientRect();
+      expect(contentRect).not.to.equal(undefined);
+      expect(navigationRect).not.to.equal(undefined);
+      if (!contentRect || !navigationRect) return;
+
+      expect(navigationRect.height).to.be.closeTo(menuRect.height, 1);
+      expect(navigationRect.width).to.be.closeTo(56, 1);
+      expect(contentRect.width).to.be.closeTo(menuRect.width - 56, 1);
+      if (direction === 'ltr') {
+        expect(contentRect.left).to.be.closeTo(menuRect.left + 56, 1);
+      } else {
+        expect(contentRect.right).to.be.closeTo(menuRect.right - 56, 1);
+      }
     });
   };
 
@@ -352,11 +376,13 @@ describe('multi-level push menu playground', () => {
 
     assertFullWidthContent(280);
     closeFromOutside();
-    assertFullWidthContent(0);
+    assertCollapsedContent();
     getMenu().should(($menu) => {
       const menuRect = $menu[0].getBoundingClientRect();
       const handleRect = $menu[0]
-        .querySelector<HTMLElement>('[data-menu-collapsed-toggle]')
+        .querySelector<HTMLElement>(
+          '.ngx-push-menu__level[data-active="true"] [data-menu-toggle]',
+        )
         ?.getBoundingClientRect();
       expect(handleRect).not.to.equal(undefined);
       if (!handleRect) return;
@@ -375,18 +401,18 @@ describe('multi-level push menu playground', () => {
     });
   });
 
-  it('keeps content full-width in cover and overlap for LTR and RTL', () => {
+  it('keeps expanded content full-width and reserves the collapsed icon rail', () => {
     cy.viewport(375, 812);
 
     assertFullWidthContent(280);
     closeFromOutside();
-    assertFullWidthContent(0);
+    assertCollapsedContent();
 
     toggleDirection('rtl');
     expandFromHandle();
     assertFullWidthContent(-280);
     closeFromOutside();
-    assertFullWidthContent(0);
+    assertCollapsedContent('rtl');
 
     cy.getByTestId('mode-overlap').click();
     expandFromHandle();

--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -280,7 +280,9 @@ describe('multi-level push menu playground', () => {
       .first()
       .should('have.attr', 'tabindex', '0');
     getActiveLevel().find('.ngx-push-menu__item-icon').should('be.visible');
-    getActiveLevel().find('.ngx-push-menu__item-label').should('not.be.visible');
+    getActiveLevel()
+      .find('.ngx-push-menu__item-label')
+      .should('not.be.visible');
     cy.getByTestId('menu-state').should('contain.text', 'Collapsed');
 
     cy.getByTestId('expand-menu').click();

--- a/apps/multi-level-push-menu-example/src/app/app.component.spec.ts
+++ b/apps/multi-level-push-menu-example/src/app/app.component.spec.ts
@@ -105,7 +105,7 @@ describe('AppComponent', () => {
     expect(fixture.componentInstance.collapsed).toBe(true);
 
     const collapsedHandle = element.querySelector<HTMLElement>(
-      '[data-menu-collapsed-toggle]',
+      '.ngx-push-menu__level[data-active="true"] [data-menu-toggle]',
     );
     expect(collapsedHandle).not.toBeNull();
 
@@ -113,7 +113,7 @@ describe('AppComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.componentInstance.collapsed).toBe(false);
-    expect(element.querySelector('[data-menu-collapsed-toggle]')).toBeNull();
+    expect(collapsedHandle?.getAttribute('aria-expanded')).toBe('true');
   });
 
   it('does not replace activation details while syncing an automatic close', () => {

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.html
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.html
@@ -24,8 +24,8 @@
     [attr.id]="options.menuID || null"
     [attr.dir]="options.direction"
     [attr.aria-label]="navigationLabel"
-    [attr.aria-hidden]="isCollapsed() ? 'true' : null"
-    [attr.inert]="isCollapsed() ? '' : null"
+    [attr.aria-hidden]="isCollapsed() && options.fullCollapse ? 'true' : null"
+    [attr.inert]="isCollapsed() && options.fullCollapse ? '' : null"
     ramiz4Swipe
     [swipeEnabled]="options.swipe"
     [overlapWidth]="overlapWidthPixels"
@@ -103,8 +103,10 @@
 
       <ul
         class="ngx-push-menu__items"
-        [attr.aria-hidden]="isCollapsed() ? 'true' : null"
-        [attr.inert]="isCollapsed() ? '' : null"
+        [attr.aria-hidden]="
+          isCollapsed() && options.fullCollapse ? 'true' : null
+        "
+        [attr.inert]="isCollapsed() && options.fullCollapse ? '' : null"
       >
         <li
           *ngFor="
@@ -126,7 +128,7 @@
             aria-haspopup="true"
             aria-expanded="false"
             [attr.tabindex]="
-              isLevelActive(levelIndex) && !isCollapsed() ? 0 : -1
+              isLevelActive(levelIndex) && !options.fullCollapse ? 0 : -1
             "
             (click)="openSubmenu(item, itemIndex, $event)"
             (keydown)="onItemKeydown($event, item, itemIndex)"
@@ -158,7 +160,9 @@
               [attr.aria-label]="itemAriaLabel(item)"
               [attr.aria-disabled]="item.disabled ? 'true' : null"
               [attr.tabindex]="
-                isLevelActive(levelIndex) && !isCollapsed() && !item.disabled
+                isLevelActive(levelIndex) &&
+                !options.fullCollapse &&
+                !item.disabled
                   ? 0
                   : -1
               "
@@ -186,7 +190,7 @@
                 [disabled]="item.disabled"
                 [attr.aria-label]="itemAriaLabel(item)"
                 [attr.tabindex]="
-                  isLevelActive(levelIndex) && !isCollapsed() ? 0 : -1
+                  isLevelActive(levelIndex) && !options.fullCollapse ? 0 : -1
                 "
                 (click)="activateItem(item, $event)"
                 (keydown)="onItemKeydown($event, item, itemIndex)"
@@ -241,26 +245,6 @@
       </button>
     </div>
   </nav>
-
-  <button
-    *ngIf="isCollapsed() && !options.fullCollapse"
-    type="button"
-    class="ngx-push-menu__collapsed-toggle"
-    data-menu-collapsed-toggle
-    data-menu-no-swipe
-    [attr.aria-label]="toggleLabel"
-    aria-expanded="false"
-    [attr.tabindex]="collapsedToggleTabIndex()"
-    [style.left]="options.direction === 'ltr' ? '0' : 'auto'"
-    [style.right]="options.direction === 'rtl' ? '0' : 'auto'"
-    (click)="expandMenu()"
-  >
-    <ramiz4-menu-icon
-      class="ngx-push-menu__toggle-icon"
-      aria-hidden="true"
-      [icon]="options.titleIcon"
-    ></ramiz4-menu-icon>
-  </button>
 
   <div
     *ngIf="!isCollapsed()"

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
@@ -43,8 +43,11 @@
   background: var(--ngx-push-menu-background, #336ca6);
   box-shadow: var(--ngx-push-menu-shadow, 0 0.5rem 1.5rem rgb(0 0 0 / 24%));
   transform: translate3d(0, 0, 0);
-  transition: transform var(--ngx-push-menu-duration, 500ms)
-    var(--ngx-push-menu-motion-easing);
+  transition:
+    inline-size var(--ngx-push-menu-duration, 500ms)
+      var(--ngx-push-menu-motion-easing),
+    transform var(--ngx-push-menu-duration, 500ms)
+      var(--ngx-push-menu-motion-easing);
   backface-visibility: hidden;
   contain: layout paint style;
   will-change: transform;
@@ -63,7 +66,13 @@
   --ngx-push-menu-motion-edge: 100%;
 }
 
-.ngx-push-menu--ltr.ngx-push-menu--collapsed .ngx-push-menu__navigation {
+.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+  .ngx-push-menu__navigation {
+  inline-size: var(--ngx-push-menu-collapsed-handle-width);
+}
+
+.ngx-push-menu--ltr.ngx-push-menu--collapsed.ngx-push-menu--full-collapse
+  .ngx-push-menu__navigation {
   transform: translate3d(
     calc(0px - var(--ngx-push-menu-effective-width)),
     0,
@@ -71,8 +80,14 @@
   );
 }
 
-.ngx-push-menu--rtl.ngx-push-menu--collapsed .ngx-push-menu__navigation {
+.ngx-push-menu--rtl.ngx-push-menu--collapsed.ngx-push-menu--full-collapse
+  .ngx-push-menu__navigation {
   transform: translate3d(var(--ngx-push-menu-effective-width), 0, 0);
+}
+
+.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+  .ngx-push-menu__level {
+  inline-size: var(--ngx-push-menu-collapsed-handle-width);
 }
 
 .ngx-push-menu__level {
@@ -168,24 +183,6 @@
   line-height: 1;
 }
 
-.ngx-push-menu__collapsed-toggle {
-  appearance: none;
-  position: absolute;
-  z-index: 200;
-  top: 0;
-  display: grid;
-  place-items: center;
-  inline-size: var(--ngx-push-menu-collapsed-handle-width);
-  min-inline-size: var(--ngx-push-menu-collapsed-handle-width);
-  block-size: 3.5rem;
-  padding: 0.75rem;
-  color: inherit;
-  background: var(--ngx-push-menu-active, #1f4164);
-  border: 0;
-  border-radius: 0;
-  cursor: pointer;
-}
-
 .ngx-push-menu__header {
   display: flex;
   align-items: center;
@@ -211,7 +208,6 @@
 }
 
 .ngx-push-menu__toggle,
-.ngx-push-menu__collapsed-toggle,
 .ngx-push-menu__back,
 .ngx-push-menu__item-control {
   appearance: none;
@@ -259,9 +255,33 @@
 }
 
 .ngx-push-menu--collapsed .ngx-push-menu__back,
-.ngx-push-menu--collapsed .ngx-push-menu__items {
+.ngx-push-menu--collapsed.ngx-push-menu--full-collapse .ngx-push-menu__items {
   visibility: hidden;
   pointer-events: none;
+}
+
+.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+  .ngx-push-menu__header {
+  gap: 0;
+  padding: 0;
+}
+
+.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+  .ngx-push-menu__header-icon,
+.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+  .ngx-push-menu__title,
+.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+  .ngx-push-menu__item-label,
+.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+  .ngx-push-menu__group-icon {
+  display: none;
+}
+
+.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+  .ngx-push-menu__item-control {
+  justify-content: center;
+  gap: 0;
+  padding-inline: 0.75rem;
 }
 
 .ngx-push-menu__item {
@@ -335,7 +355,6 @@
 }
 
 .ngx-push-menu__toggle:focus-visible,
-.ngx-push-menu__collapsed-toggle:focus-visible,
 .ngx-push-menu__back:focus-visible,
 .ngx-push-menu__item-control:focus-visible,
 .ngx-push-menu__rail:focus-visible {
@@ -361,6 +380,12 @@
   backface-visibility: hidden;
   will-change: transform;
   -webkit-overflow-scrolling: touch;
+}
+
+.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+  .ngx-push-menu__content {
+  inset-inline-start: var(--ngx-push-menu-collapsed-handle-width);
+  inline-size: calc(100% - var(--ngx-push-menu-collapsed-handle-width));
 }
 
 .ngx-push-menu--cover.ngx-push-menu--ltr:not(.ngx-push-menu--collapsed)
@@ -485,7 +510,6 @@
   .ngx-push-menu__navigation,
   .ngx-push-menu__level,
   .ngx-push-menu__rail,
-  .ngx-push-menu__collapsed-toggle,
   .ngx-push-menu__header,
   .ngx-push-menu__back,
   .ngx-push-menu__item-control {

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
@@ -382,9 +382,17 @@
   -webkit-overflow-scrolling: touch;
 }
 
-.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+.ngx-push-menu--ltr.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
   .ngx-push-menu__content {
-  inset-inline-start: var(--ngx-push-menu-collapsed-handle-width);
+  right: auto;
+  left: var(--ngx-push-menu-collapsed-handle-width);
+  inline-size: calc(100% - var(--ngx-push-menu-collapsed-handle-width));
+}
+
+.ngx-push-menu--rtl.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+  .ngx-push-menu__content {
+  right: var(--ngx-push-menu-collapsed-handle-width);
+  left: auto;
   inline-size: calc(100% - var(--ngx-push-menu-collapsed-handle-width));
 }
 

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.spec.ts
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.spec.ts
@@ -89,28 +89,22 @@ describe('MultiLevelPushMenuComponent', () => {
     ).toBe(-1);
   });
 
-  it('keeps only the visible toggle reachable when partially collapsed', () => {
+  it('keeps the full-height icon rail reachable when partially collapsed', () => {
     component.collapseMenu();
     fixture.detectChanges();
 
     expect(
       element.querySelector<HTMLElement>('.ngx-push-menu__toggle')?.tabIndex,
-    ).toBe(-1);
-    expect(
-      element.querySelector<HTMLElement>('[data-menu-collapsed-toggle]')
-        ?.tabIndex,
     ).toBe(0);
     expect(
       Array.from(
-        element.querySelectorAll<HTMLElement>(
-          '.ngx-push-menu__item-control, .ngx-push-menu__back',
-        ),
-      ).every((control) => control.tabIndex === -1),
+        element.querySelectorAll<HTMLElement>('.ngx-push-menu__item-control'),
+      ).some((control) => control.tabIndex === 0),
     ).toBe(true);
     expect(
       element.querySelector('.ngx-push-menu__items')?.hasAttribute('inert'),
-    ).toBe(true);
-    expect(element.querySelector('nav')?.hasAttribute('inert')).toBe(true);
+    ).toBe(false);
+    expect(element.querySelector('nav')?.hasAttribute('inert')).toBe(false);
   });
 
   it('closes from the backdrop outside the navigation', () => {
@@ -250,7 +244,7 @@ describe('MultiLevelPushMenuComponent', () => {
     expect(levelChangeSpy).toHaveBeenLastCalledWith(0);
   });
 
-  it('uses and focuses the dedicated collapsed toggle at every depth', async () => {
+  it('keeps and focuses the active level icon rail at every depth', async () => {
     const deepMenu: MultiLevelPushMenuItem[] = [
       {
         name: 'Products',
@@ -288,21 +282,20 @@ describe('MultiLevelPushMenuComponent', () => {
       element
         .querySelector<HTMLElement>('.ngx-push-menu__level[data-active="true"]')
         ?.hasAttribute('inert'),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       element.querySelector<HTMLButtonElement>(
         '.ngx-push-menu__level[data-active="true"] [data-menu-toggle]',
       )?.tabIndex,
-    ).toBe(-1);
+    ).toBe(0);
     const collapsedToggle = element.querySelector<HTMLButtonElement>(
-      '[data-menu-collapsed-toggle]',
+      '.ngx-push-menu__level[data-active="true"] [data-menu-toggle]',
     );
     expect(collapsedToggle?.getAttribute('aria-label')).toBe(
       'Expand Main navigation',
     );
     expect(collapsedToggle?.tabIndex).toBe(0);
-    expect(collapsedToggle?.closest('nav')).toBeNull();
-    expect(collapsedToggle?.style.left).toBe('0px');
+    expect(collapsedToggle?.closest('nav')).not.toBeNull();
     await nextAnimationFrame();
     expect(element.ownerDocument.activeElement).toBe(collapsedToggle);
 

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.ts
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.ts
@@ -303,7 +303,10 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
 
   /** @internal */
   protected isLevelAccessible(index: number): boolean {
-    return this.isLevelActive(index) && !this.isCollapsed();
+    return (
+      this.isLevelActive(index) &&
+      (!this.isCollapsed() || !this._options.fullCollapse)
+    );
   }
 
   /** @internal */
@@ -324,12 +327,9 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
 
   /** @internal */
   protected activeToggleTabIndex(levelIndex: number): number {
-    return this.isLevelActive(levelIndex) && !this.isCollapsed() ? 0 : -1;
-  }
-
-  /** @internal */
-  protected collapsedToggleTabIndex(): number {
-    return this.isCollapsed() && !this._options.fullCollapse ? 0 : -1;
+    return this.isLevelActive(levelIndex) && !this._options.fullCollapse
+      ? 0
+      : -1;
   }
 
   /** @internal */
@@ -816,7 +816,7 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
 
     if (shouldRestoreFocus) {
       if (this._options.fullCollapse) this.scheduleContentFocus();
-      else this.scheduleFocus('[data-menu-collapsed-toggle]', false);
+      else this.scheduleFocus('[data-menu-toggle]');
     }
   }
 
@@ -990,7 +990,7 @@ export class MultiLevelPushMenuComponent implements OnDestroy {
   private scheduleActiveLevelFocus(): void {
     if (this.isCollapsed()) {
       if (this._options.fullCollapse) this.scheduleContentFocus();
-      else this.scheduleFocus('[data-menu-collapsed-toggle]', false);
+      else this.scheduleFocus('[data-menu-toggle]');
       return;
     }
 


### PR DESCRIPTION
## Summary
- replace the floating collapsed toggle with a full-height 56px icon rail
- keep active-level item icons and the header toggle accessible while labels stay hidden
- reserve the rail width from projected/router content in LTR and RTL
- preserve `fullCollapse` as the fully hidden opt-in behavior
- cover rail height, width, content geometry, focus, Chrome and WebKit behavior

## Validation
- `npm run validate` (56 unit tests, lint, builds, package validation)