### PR TITLE
docs(demo): document the 20.2.0 icon rail release

### DIFF
--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -254,7 +254,7 @@ describe('multi-level push menu playground', () => {
     cy.getByTestId('route-release-notes').scrollIntoView();
     cy.getByTestId('route-release-notes')
       .should('be.visible')
-      .and('contain.text', '20.1.0');
+      .and('contain.text', '20.2.0');
     cy.get('#demo-heading').should('not.exist');
 
     expandFromHandle();

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.html
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.html
@@ -9,11 +9,11 @@
 
   <div class="demo-release-list">
     <section>
-      <div><strong>20.1.0</strong><span>Latest</span></div>
-      <h3>Smoother, continuous navigation</h3>
+      <div><strong>20.2.0</strong><span>Latest</span></div>
+      <h3>Complete collapsed icon rails</h3>
       <p>
-        Persistent entering and exiting panels, synchronized 500 ms
-        GPU-composited transitions and stable Chrome/WebKit coverage.
+        Full-height collapsed navigation, accessible Back controls and a
+        configurable fallback icon for every menu item.
       </p>
     </section>
     <section>

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
@@ -17,7 +17,7 @@ describe('ReleaseNotesComponent', () => {
     expect(
       element.querySelector('[data-testid="route-release-notes"]'),
     ).not.toBeNull();
-    expect(element.textContent).toContain('20.1.0');
-    expect(element.textContent).toContain('Smoother, continuous navigation');
+    expect(element.textContent).toContain('20.2.0');
+    expect(element.textContent).toContain('Complete collapsed icon rails');
   });
 });


### PR DESCRIPTION
Update the live release notes and assertions for the newly published Back-control and fallback-icon release.