### PR TITLE
fix: pin overlap rail icons to the top

### DIFF
--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -178,7 +178,14 @@ describe('multi-level push menu playground', () => {
 
       rails.forEach((rail, index) => {
         const railRect = rail.getBoundingClientRect();
+        const railHeaderRect = rail
+          .querySelector<HTMLElement>('.ngx-push-menu__rail-header')
+          ?.getBoundingClientRect();
         expect(railRect.width).to.be.closeTo(40, 1);
+        expect(railHeaderRect).not.to.equal(undefined);
+        if (railHeaderRect) {
+          expect(railHeaderRect.top).to.be.closeTo(railRect.top, 1);
+        }
         if (direction === 'ltr') {
           expect(railRect.left).to.be.closeTo(activeRect.right + index * 40, 1);
         } else {

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
@@ -140,7 +140,10 @@
 .ngx-push-menu__rail {
   appearance: none;
   position: relative;
+  display: flex;
   flex: 0 0 var(--ngx-push-menu-overlap);
+  align-items: flex-start;
+  justify-content: flex-start;
   inline-size: var(--ngx-push-menu-overlap);
   min-inline-size: 0;
   padding: 0;
@@ -166,6 +169,7 @@
 
 .ngx-push-menu__rail-header {
   display: grid;
+  flex: 0 0 100%;
   place-items: center;
   inline-size: 100%;
   min-block-size: 3.5rem;


### PR DESCRIPTION
## Summary
- make each overlap ancestor rail an explicit top-aligned flex container
- pin its icon header to the rail's upper edge across browser button implementations
- assert exact rail/header top geometry in Chrome and WebKit

## Validation
- `npm run validate`