### PR TITLE
docs(demo): document the 20.2.1 rail alignment fix

### DIFF
--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -261,7 +261,7 @@ describe('multi-level push menu playground', () => {
     cy.getByTestId('route-release-notes').scrollIntoView();
     cy.getByTestId('route-release-notes')
       .should('be.visible')
-      .and('contain.text', '20.2.0');
+      .and('contain.text', '20.2.1');
     cy.get('#demo-heading').should('not.exist');
 
     expandFromHandle();

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.html
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.html
@@ -9,11 +9,12 @@
 
   <div class="demo-release-list">
     <section>
-      <div><strong>20.2.0</strong><span>Latest</span></div>
-      <h3>Complete collapsed icon rails</h3>
+      <div><strong>20.2.1</strong><span>Latest</span></div>
+      <h3>Polished collapsed and overlap rails</h3>
       <p>
         Full-height collapsed navigation, accessible Back controls and a
-        configurable fallback icon for every menu item.
+        configurable fallback icon for every menu item, with overlap icons
+        pinned consistently to the top.
       </p>
     </section>
     <section>

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
@@ -17,7 +17,9 @@ describe('ReleaseNotesComponent', () => {
     expect(
       element.querySelector('[data-testid="route-release-notes"]'),
     ).not.toBeNull();
-    expect(element.textContent).toContain('20.2.0');
-    expect(element.textContent).toContain('Complete collapsed icon rails');
+    expect(element.textContent).toContain('20.2.1');
+    expect(element.textContent).toContain(
+      'Polished collapsed and overlap rails',
+    );
   });
 });


### PR DESCRIPTION
Align the live release notes and assertions with the newly published overlap rail icon alignment fix.