### PR TITLE
fix: keep overlap content geometry stable

### DIFF
--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -164,12 +164,14 @@ describe('multi-level push menu playground', () => {
         1,
       );
       expect(activeRect.width).to.be.closeTo(280, 1);
-      expect(contentRect.width).to.be.closeTo(menuRect.width, 1);
-      expect(contentRect.left).to.be.closeTo(menuRect.left, 1);
-      expect(contentRect.right).to.be.closeTo(menuRect.right, 1);
+      expect(contentRect.width).to.be.closeTo(menuRect.width - 56, 1);
       if (direction === 'ltr') {
+        expect(contentRect.left).to.be.closeTo(menuRect.left + 56, 1);
+        expect(contentRect.right).to.be.closeTo(menuRect.right, 1);
         expect(activeRect.left).to.be.closeTo(navigationRect.left, 1);
       } else {
+        expect(contentRect.left).to.be.closeTo(menuRect.left, 1);
+        expect(contentRect.right).to.be.closeTo(menuRect.right - 56, 1);
         expect(activeRect.right).to.be.closeTo(navigationRect.right, 1);
       }
       expect(
@@ -444,7 +446,7 @@ describe('multi-level push menu playground', () => {
 
     cy.getByTestId('mode-overlap').click();
     expandFromHandle();
-    assertFullWidthContent(0);
+    assertOverlapGeometry([], 'rtl');
     closeFromOutside();
   });
 

--- a/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
+++ b/libs/ngx-multi-level-push-menu/src/lib/multi-level-push-menu/multi-level-push-menu.component.scss
@@ -395,14 +395,20 @@
   -webkit-overflow-scrolling: touch;
 }
 
-.ngx-push-menu--ltr.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+.ngx-push-menu--ltr:not(.ngx-push-menu--full-collapse):is(
+    .ngx-push-menu--collapsed,
+    .ngx-push-menu--overlap
+  )
   .ngx-push-menu__content {
   right: auto;
   left: var(--ngx-push-menu-collapsed-handle-width);
   inline-size: calc(100% - var(--ngx-push-menu-collapsed-handle-width));
 }
 
-.ngx-push-menu--rtl.ngx-push-menu--collapsed:not(.ngx-push-menu--full-collapse)
+.ngx-push-menu--rtl:not(.ngx-push-menu--full-collapse):is(
+    .ngx-push-menu--collapsed,
+    .ngx-push-menu--overlap
+  )
   .ngx-push-menu__content {
   right: var(--ngx-push-menu-collapsed-handle-width);
   left: auto;


### PR DESCRIPTION
## Summary
- reserve the collapsed icon-rail width for overlap content while both closed and open
- keep Router Outlet width and position identical throughout the overlap transition
- overlay the expanding navigation without reflowing background content
- cover LTR, RTL, root overlap and nested overlap geometry in Chrome and WebKit

## Validation
- `npm run validate` (56 unit tests, lint, library/demo builds, package validation)