### PR TITLE
docs(demo): document stable overlap geometry in 20.2.2

### DIFF
--- a/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
+++ b/apps/multi-level-push-menu-example-e2e/src/e2e/app.cy.ts
@@ -263,7 +263,7 @@ describe('multi-level push menu playground', () => {
     cy.getByTestId('route-release-notes').scrollIntoView();
     cy.getByTestId('route-release-notes')
       .should('be.visible')
-      .and('contain.text', '20.2.1');
+      .and('contain.text', '20.2.2');
     cy.get('#demo-heading').should('not.exist');
 
     expandFromHandle();

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.html
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.html
@@ -9,12 +9,11 @@
 
   <div class="demo-release-list">
     <section>
-      <div><strong>20.2.1</strong><span>Latest</span></div>
-      <h3>Polished collapsed and overlap rails</h3>
+      <div><strong>20.2.2</strong><span>Latest</span></div>
+      <h3>Stable overlap content geometry</h3>
       <p>
-        Full-height collapsed navigation, accessible Back controls and a
-        configurable fallback icon for every menu item, with overlap icons
-        pinned consistently to the top.
+        Router Outlet width and position remain fixed while overlap navigation
+        opens, preventing background reflow and visual jank.
       </p>
     </section>
     <section>

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
@@ -17,9 +17,9 @@ describe('ReleaseNotesComponent', () => {
     expect(
       element.querySelector('[data-testid="route-release-notes"]'),
     ).not.toBeNull();
-    expect(element.textContent).toContain('20.2.1');
+    expect(element.textContent).toContain('20.2.2');
     expect(element.textContent).toContain(
-      'Polished collapsed and overlap rails',
+      'Stable overlap content geometry',
     );
   });
 });

--- a/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
+++ b/apps/multi-level-push-menu-example/src/app/release-notes/release-notes.component.spec.ts
@@ -18,8 +18,6 @@ describe('ReleaseNotesComponent', () => {
       element.querySelector('[data-testid="route-release-notes"]'),
     ).not.toBeNull();
     expect(element.textContent).toContain('20.2.2');
-    expect(element.textContent).toContain(
-      'Stable overlap content geometry',
-    );
+    expect(element.textContent).toContain('Stable overlap content geometry');
   });
 });


### PR DESCRIPTION
Align the live release notes and assertions with the newly published stable overlap content geometry fix.